### PR TITLE
[front] fix: fix autocomplete for Turkish cities

### DIFF
--- a/frontend/src/components/form/city-dropdown.tsx
+++ b/frontend/src/components/form/city-dropdown.tsx
@@ -141,7 +141,7 @@ const CityDropdown = ({
     try {
       setIsLoading(true);
       const response = await axios.get(
-        `${PHOTON_API_URL}/api?q=${newQuery}&layer=city&limit=10`,
+        `${PHOTON_API_URL}/api?q=${newQuery}&osm_tag=place:city&&osm_tag=place:village&layer=city&layer=district&limit=10`,
       );
       const cities = formatCities(response.data.features as PhotonApiCity[]);
       addToCache(newQuery, cities);


### PR DESCRIPTION
The autocomplete input seems broken for the Turkish cities (impossible to find Ankara or Istanbul).

Apparently, the Turkish cities are mainly in the osm district layer, but the app only uses the city layer.