### PR TITLE
When formatting the city's name, don't use the state if it's undefined

### DIFF
--- a/frontend/src/components/form/city-dropdown.tsx
+++ b/frontend/src/components/form/city-dropdown.tsx
@@ -20,7 +20,7 @@ const formatCityName = (
   city: PhotonApiCity["properties"],
 ) => {
   const cityName = `${city.name}, ${city.country}`;
-  if (duplicates.includes(cityName)) {
+  if (duplicates.includes(cityName) && city.state) {
     return `${city.name}, ${city.state}, ${city.country}`;
   }
   return cityName;


### PR DESCRIPTION
For example, Lisboa doesn't have a state so it's displayed as "Lisboa, undefined, Portugal".

Before/After

<img width="401" alt="Capture d’écran 2024-06-03 à 10 38 54" src="https://github.com/XavB64/lowtrip/assets/928878/9c2de602-57cf-4061-9299-1eb050966721">
<img width="395" alt="Capture d’écran 2024-06-03 à 10 38 36" src="https://github.com/XavB64/lowtrip/assets/928878/bd09ef17-c8b0-457e-a51e-43914d4d5e70">

When searching for "Lisboa" using the API it returns both the city of Lisbon and the district. 

```json
{
			"geometry": {
				"coordinates": [
					-9.1365919,
					38.7077507
				],
				"type": "Point"
			},
			"type": "Feature",
			"properties": {
				"osm_type": "N",
				"osm_id": 265958490,
				"country": "Portugal",
				"osm_key": "place",
				"city": "Lisbon",
				"countrycode": "PT",
				"osm_value": "city",
				"postcode": "1100-148",
				"name": "Lisbon",
				"county": "Lisbon",
				"type": "district"
			}
		},
		{
			"geometry": {
				"coordinates": [
					-9.151827931741947,
					38.7440523
				],
				"type": "Point"
			},
			"type": "Feature",
			"properties": {
				"osm_type": "R",
				"osm_id": 5400890,
				"extent": [
					-9.2298356,
					38.7967584,
					-9.0863328,
					38.6913994
				],
				"country": "Portugal",
				"osm_key": "place",
				"countrycode": "PT",
				"osm_value": "city",
				"name": "Lisbon",
				"county": "Lisbon",
				"type": "city"
			}
		},
```

If you would like to display both a separate entries, we could format it as "Lisboa, Portugal (city)" and "Lisboa, Portugal (disctrict)". 

It would be more work as the type needs to be piped through and the type needs to be translated, but it might be more resilient to some edge cases I'm not aware of.