### PR TITLE
tools: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/backend/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "back:"
+    open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "npm"
+    directory: "/frontend/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "front:"
+    open-pull-requests-limit: 100
+    labels:
+      - "dependencies"
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
This commit introduces a .github/dependabot.yml file to enable Dependabot on this repository.

Dependabot is a GitHub-native tool that automatically checks for outdated or insecure dependencies and opens pull requests to keep them up to date. This helps improve security, stability, and maintainability over time.