### PR TITLE
🔧 back: specialize StepData by transport type

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -16,6 +16,12 @@
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
+from typing import Literal
+
+
+######################
+# INPUTS
+######################
 
 
 @dataclass
@@ -40,6 +46,11 @@ class TripStep:
     options: str | None
 
 
+######################
+# OUTPUTS
+######################
+
+
 @dataclass
 class TripStepGeometry:
     """Trip step geometry."""
@@ -62,12 +73,99 @@ class EmissionPart:
 
 
 @dataclass
-class StepData:
-    """Emissions of the trip step."""
+class BaseStepData:
+    """Base step dataclass."""
 
     transport_means: str
     emissions: list[EmissionPart]
     path_length: float
+
+
+@dataclass
+class BicycleStepData(BaseStepData):
+    """Bicycle step dataclass."""
+
+    transport_means: Literal["bicycle"]
+    coeff_upstream: float
+
+
+@dataclass
+class BusStepData(BaseStepData):
+    """Bus step dataclass."""
+
+    transport_means: Literal["bus"]
+    coeff_upstream: float
+    coeff_fuel: float
+
+
+@dataclass
+class CarStepData(BaseStepData):
+    """Car step dataclass."""
+
+    transport_means: Literal["car"]
+    is_hitch_hike: bool
+    passengers_nb: int
+    coeff_upstream: float
+    coeff_fuel: float
+
+
+@dataclass
+class EcarStepData(BaseStepData):
+    """ECar step dataclass."""
+
+    transport_means: Literal["ecar"]
+    passengers_nb: int
+    coeff_upstream: float
+    coeff_fuel: float
+
+
+@dataclass
+class FerryStepData(BaseStepData):
+    """Ferry step dataclass."""
+
+    transport_means: Literal["ferry"]
+    coeff_total: float
+    options: str
+
+
+@dataclass
+class PlaneStepData(BaseStepData):
+    """Plane step dataclass."""
+
+    transport_means: Literal["plane"]
+    coeff_path_detour: float
+    coeff_contrails: float
+    coeff_fuel: float
+    coeff_upstream: float
+    holding: float
+
+
+@dataclass
+class TrainStepData(BaseStepData):
+    """Train step dataclass."""
+
+    transport_means: Literal["train"]
+    coeff_upstream: float
+
+
+@dataclass
+class SailStepData(BaseStepData):
+    """Sail step dataclass."""
+
+    transport_means: Literal["sail"]
+    coeff_total: float
+
+
+StepData = (
+    BicycleStepData
+    | BusStepData
+    | CarStepData
+    | EcarStepData
+    | FerryStepData
+    | PlaneStepData
+    | SailStepData
+    | TrainStepData
+)
 
 
 @dataclass

--- a/backend/transport_bicycle.py
+++ b/backend/transport_bicycle.py
@@ -22,8 +22,8 @@ import requests
 from shapely.geometry import LineString
 
 from models import (
+    BicycleStepData,
     EmissionPart,
-    StepData,
     TripStepGeometry,
     TripStepResult,
 )
@@ -95,7 +95,7 @@ def bicycle_to_gdf(
         return None
 
     return TripStepResult(
-        step_data=StepData(
+        step_data=BicycleStepData(
             transport_means="bicycle",
             emissions=[
                 EmissionPart(
@@ -106,6 +106,7 @@ def bicycle_to_gdf(
                 ),
             ],
             path_length=route_length,
+            coeff_upstream=EF,
         ),
         geometries=[
             TripStepGeometry(

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -23,8 +23,10 @@ import requests
 from shapely.geometry import LineString
 
 from models import (
+    BusStepData,
+    CarStepData,
+    EcarStepData,
     EmissionPart,
-    StepData,
     TripStepGeometry,
     TripStepResult,
 )
@@ -43,8 +45,8 @@ class CarBusResults:
     """Dataclass for car and bus emissions and road geometry."""
 
     geometries: list[TripStepGeometry]
-    bus_step_data: StepData
-    car_step_data: StepData
+    bus_step_data: BusStepData
+    car_step_data: CarStepData
 
 
 OSM_ROUTER_URL = "http://router.project-osrm.org/route/v1/driving"
@@ -173,10 +175,13 @@ def ecar_to_gdf(
     ]
 
     return TripStepResult(
-        step_data=StepData(
+        step_data=EcarStepData(
             transport_means="ecar",
             emissions=emissions,
             path_length=route_length,
+            passengers_nb=passengers_nb,
+            coeff_upstream=EF_ecar["construction"],
+            coeff_fuel=EF_ecar["fuel"],
         ),
         geometries=geometries,
     )
@@ -294,15 +299,21 @@ def car_bus_to_gdf(
 
     return CarBusResults(
         geometries=[road_geometry],
-        bus_step_data=StepData(
+        bus_step_data=BusStepData(
             transport_means="bus",
             emissions=bus_emissions,
             path_length=route_length,
+            coeff_upstream=EF_bus["fuel"],
+            coeff_fuel=EF_bus["construction"],
         ),
-        car_step_data=StepData(
+        car_step_data=CarStepData(
             transport_means="car",
             emissions=car_emissions,
             path_length=route_length,
+            passengers_nb=1,
+            is_hitch_hike=False,
+            coeff_upstream=EF_car["fuel"],
+            coeff_fuel=EF_car["construction"],
         ),
     )
 
@@ -346,10 +357,12 @@ def bus_to_gdf(
     )
 
     return TripStepResult(
-        step_data=StepData(
+        step_data=BusStepData(
             transport_means="Bus",
             emissions=emissions,
             path_length=route_length,
+            coeff_upstream=EF_bus["construction"],
+            coeff_fuel=EF_bus["fuel"],
         ),
         geometries=[road_geometry],
     )
@@ -397,7 +410,7 @@ def car_to_gdf(
     geometry = get_road_geometry_data(route_length, route_geometry, color_usage)
 
     return TripStepResult(
-        step_data=StepData(
+        step_data=CarStepData(
             transport_means="car",
             emissions=get_car_emissions(
                 route_length,
@@ -406,7 +419,11 @@ def car_to_gdf(
                 color_usage,
                 color_cons,
             ),
+            is_hitch_hike=False,
+            passengers_nb=passengers_nb,
             path_length=route_length,
+            coeff_upstream=EF_car["construction"],
+            coeff_fuel=EF_car["fuel"],
         ),
         geometries=[geometry],
     )

--- a/backend/transport_ferry.py
+++ b/backend/transport_ferry.py
@@ -29,7 +29,8 @@ from shapely.ops import nearest_points, unary_union
 
 from models import (
     EmissionPart,
-    StepData,
+    FerryStepData,
+    SailStepData,
     TripStepGeometry,
     TripStepResult,
 )
@@ -253,7 +254,7 @@ def ferry_to_gdf(
         coordinates.append(t)
 
     return TripStepResult(
-        step_data=StepData(
+        step_data=FerryStepData(
             transport_means="ferry",
             emissions=[
                 EmissionPart(
@@ -264,6 +265,8 @@ def ferry_to_gdf(
                 ),
             ],
             path_length=bird,
+            coeff_total=EF,
+            options=options,
         ),
         geometries=[
             TripStepGeometry(
@@ -305,7 +308,7 @@ def sail_to_gdf(tag1, tag2, EF=EF_sail, color_usage="#ffffff") -> TripStepResult
         coordinates.append(t)
 
     return TripStepResult(
-        step_data=StepData(
+        step_data=SailStepData(
             transport_means="sail",
             emissions=[
                 EmissionPart(
@@ -316,6 +319,7 @@ def sail_to_gdf(tag1, tag2, EF=EF_sail, color_usage="#ffffff") -> TripStepResult
                 ),
             ],
             path_length=bird,
+            coeff_total=EF,
         ),
         geometries=[
             TripStepGeometry(

--- a/backend/transport_plane.py
+++ b/backend/transport_plane.py
@@ -20,7 +20,7 @@ from shapely.geometry import LineString
 
 from models import (
     EmissionPart,
-    StepData,
+    PlaneStepData,
     TripStepGeometry,
     TripStepResult,
 )
@@ -144,7 +144,7 @@ def plane_to_gdf(
     CO2_factors = emissions_factors["combustion"] + emissions_factors["upstream"]
     non_CO2_factors = emissions_factors["combustion"] * contrails
 
-    step_data = StepData(
+    step_data = PlaneStepData(
         transport_means="plane",
         emissions=[
             EmissionPart(
@@ -161,6 +161,11 @@ def plane_to_gdf(
             ),
         ],
         path_length=route_length,
+        coeff_path_detour=detour,
+        coeff_contrails=contrails,
+        coeff_fuel=emissions_factors["combustion"],
+        coeff_upstream=emissions_factors["upstream"],
+        holding=holding,
     )
 
     return TripStepResult(

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -28,7 +28,7 @@ from shapely.geometry import (
 
 from models import (
     EmissionPart,
-    StepData,
+    TrainStepData,
     TripStepGeometry,
     TripStepResult,
 )
@@ -338,10 +338,11 @@ def train_to_gdf(
     ]
 
     return TripStepResult(
-        step_data=StepData(
+        step_data=TrainStepData(
             transport_means="train",
             emissions=emissions,
             path_length=train_dist,
+            coeff_upstream=EF_train["infra"],
         ),
         geometries=geometries,
     )


### PR DESCRIPTION
Replace generic StepData with transport-specific dataclasses (PlaneStepData, TrainStepData, etc.) to better reflect domain logic and differences in emission modeling.