### PR TITLE
🧹📦 front: remove @types/google.maps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -26,7 +26,6 @@
         "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
         "@eslint/js": "^9.39.4",
         "@types/d3-ease": "^3.0.2",
-        "@types/google.maps": "^3.58.1",
         "@types/katex": "^0.16.7",
         "@types/leaflet": "^1.9.21",
         "@types/node": "^25.6.0",
@@ -1543,13 +1542,6 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/google.maps": {
-      "version": "3.58.1",
-      "resolved": "https://registry.npmjs.org/@types/google.maps/-/google.maps-3.58.1.tgz",
-      "integrity": "sha512-X9QTSvGJ0nCfMzYOnaVs/k6/4L+7F5uCS+4iUmkLEls6J9S/Phv+m/i3mDeyc49ZBgwab3EFO1HEoBY7k98EGQ==",
       "dev": true,
       "license": "MIT"
     },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,7 +21,6 @@
     "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
     "@eslint/js": "^9.39.4",
     "@types/d3-ease": "^3.0.2",
-    "@types/google.maps": "^3.58.1",
     "@types/katex": "^0.16.7",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^25.6.0",


### PR DESCRIPTION
Google.maps was removed in 63bef80558fb83b9f903db5d60bab77311c074c5, so this dependency is not needed anymore.