### PR TITLE
Move colors to frontend

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -30,7 +30,6 @@ from flask_cors import CORS
 import requests
 
 from backend import compute_custom_trip_emissions, compute_direct_trips_emissions
-from parameters import colors_alternative
 from utils import extract_path_steps_from_payload
 
 
@@ -70,7 +69,6 @@ def main():
             second_trip, second_trip_geometries = compute_custom_trip_emissions(
                 "SECOND_TRIP",
                 alternative_trip_inputs,
-                cmap=colors_alternative,
             )
             trips = [main_trip, second_trip]
             geometries += second_trip_geometries

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -30,6 +30,7 @@ from models import (
     TripResult,
     TripStep,
     TripStepGeometry,
+    TripType,
 )
 from parameters import (
     colors_custom,
@@ -76,6 +77,7 @@ def compute_custom_trip_emissions(
     """
     emissions_data: list[StepData] = []
     geometries: list[TripStepGeometry] = []
+    trip_type: TripType = "MAIN_TRIP" if name == "MAIN_TRIP" else "SECOND_TRIP"
 
     for idx in range(len(trip_inputs) - 1):  # We loop until last departure
         # Departure coordinates
@@ -95,6 +97,7 @@ def compute_custom_trip_emissions(
             results = train_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                trip_type,
                 color_usage=cmap["Train"],
                 color_infra=cmap["Cons_infra"],
             )
@@ -103,6 +106,7 @@ def compute_custom_trip_emissions(
             results = bus_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                trip_type,
                 color_usage=cmap["Road"],
                 color_cons=cmap["Cons_infra"],
             )
@@ -111,6 +115,7 @@ def compute_custom_trip_emissions(
             results = car_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                trip_type,
                 passengers_nb=arrival.passengers_nb,
                 color_usage=cmap["Road"],
                 color_cons=cmap["Cons_infra"],
@@ -120,6 +125,7 @@ def compute_custom_trip_emissions(
             results = ecar_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                trip_type,
                 passengers_nb=arrival.passengers_nb,
                 color_usage=cmap["Road"],
                 color_cons=cmap["Cons_infra"],
@@ -129,6 +135,7 @@ def compute_custom_trip_emissions(
             results = bicycle_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                trip_type,
                 color=cmap["Bicycle"],
             )
 
@@ -136,6 +143,7 @@ def compute_custom_trip_emissions(
             results = plane_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                trip_type,
                 color_usage=cmap["Plane"],
                 color_contrails=cmap["Contrails"],
             )
@@ -144,6 +152,7 @@ def compute_custom_trip_emissions(
             results = ferry_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                trip_type,
                 color_usage=cmap["Ferry"],
                 options=arrival.options,
             )
@@ -152,6 +161,7 @@ def compute_custom_trip_emissions(
             results = sail_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                trip_type,
                 color_usage=cmap["Ferry"],
             )
 
@@ -196,6 +206,7 @@ def compute_direct_trips_emissions(inputs: list[TripStep], cmap=colors_direct):
             train_results = train_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                "DIRECT_TRIP",
                 color_usage=cmap["Train"],
                 color_infra=cmap["Cons_infra"],
             )
@@ -227,6 +238,7 @@ def compute_direct_trips_emissions(inputs: list[TripStep], cmap=colors_direct):
             plane_result = plane_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,
+                "DIRECT_TRIP",
                 color_usage=cmap["Plane"],
                 color_contrails=cmap["Contrails"],
             )

--- a/backend/backend.py
+++ b/backend/backend.py
@@ -33,8 +33,6 @@ from models import (
     TripType,
 )
 from parameters import (
-    colors_custom,
-    colors_direct,
     min_plane_dist,
 )
 from transport_bicycle import bicycle_to_gdf
@@ -57,7 +55,6 @@ from transport_train import train_to_gdf
 def compute_custom_trip_emissions(
     name: str,
     trip_inputs: list[TripStep],
-    cmap=colors_custom,
 ):
     """Parameters
     ----------
@@ -98,8 +95,6 @@ def compute_custom_trip_emissions(
                 departure_coordinates,
                 arrival_coordinates,
                 trip_type,
-                color_usage=cmap["Train"],
-                color_infra=cmap["Cons_infra"],
             )
 
         elif transport_means == "bus":
@@ -107,8 +102,6 @@ def compute_custom_trip_emissions(
                 departure_coordinates,
                 arrival_coordinates,
                 trip_type,
-                color_usage=cmap["Road"],
-                color_cons=cmap["Cons_infra"],
             )
 
         elif transport_means == "car":
@@ -117,8 +110,6 @@ def compute_custom_trip_emissions(
                 arrival_coordinates,
                 trip_type,
                 passengers_nb=arrival.passengers_nb,
-                color_usage=cmap["Road"],
-                color_cons=cmap["Cons_infra"],
             )
 
         elif transport_means == "ecar":
@@ -127,8 +118,6 @@ def compute_custom_trip_emissions(
                 arrival_coordinates,
                 trip_type,
                 passengers_nb=arrival.passengers_nb,
-                color_usage=cmap["Road"],
-                color_cons=cmap["Cons_infra"],
             )
 
         elif transport_means == "bicycle":
@@ -136,7 +125,6 @@ def compute_custom_trip_emissions(
                 departure_coordinates,
                 arrival_coordinates,
                 trip_type,
-                color=cmap["Bicycle"],
             )
 
         elif transport_means == "plane":
@@ -144,8 +132,6 @@ def compute_custom_trip_emissions(
                 departure_coordinates,
                 arrival_coordinates,
                 trip_type,
-                color_usage=cmap["Plane"],
-                color_contrails=cmap["Contrails"],
             )
 
         elif transport_means == "ferry":
@@ -153,7 +139,6 @@ def compute_custom_trip_emissions(
                 departure_coordinates,
                 arrival_coordinates,
                 trip_type,
-                color_usage=cmap["Ferry"],
                 options=arrival.options,
             )
 
@@ -162,7 +147,6 @@ def compute_custom_trip_emissions(
                 departure_coordinates,
                 arrival_coordinates,
                 trip_type,
-                color_usage=cmap["Ferry"],
             )
 
         if results is None:  # Step is not successful
@@ -175,7 +159,7 @@ def compute_custom_trip_emissions(
     return TripResult(name=name, steps=emissions_data), geometries
 
 
-def compute_direct_trips_emissions(inputs: list[TripStep], cmap=colors_direct):
+def compute_direct_trips_emissions(inputs: list[TripStep]):
     """Compute emissions for the same trip, but with other transport means given the initial transport means used,
     the departure and arrival coordinates.
 
@@ -207,19 +191,14 @@ def compute_direct_trips_emissions(inputs: list[TripStep], cmap=colors_direct):
                 departure_coordinates,
                 arrival_coordinates,
                 "DIRECT_TRIP",
-                color_usage=cmap["Train"],
-                color_infra=cmap["Cons_infra"],
             )
             if train_results is not None:
                 trips.append(TripResult(name="TRAIN", steps=[train_results.step_data]))
                 geometries += train_results.geometries
 
-        cmap_road = colors_custom if transport_means == "ecar" else cmap
         road_results = car_bus_to_gdf(
             departure_coordinates,
             arrival_coordinates,
-            color_usage=cmap_road["Road"],
-            color_cons=cmap_road["Cons_infra"],
         )
 
         if road_results is not None:
@@ -239,8 +218,6 @@ def compute_direct_trips_emissions(inputs: list[TripStep], cmap=colors_direct):
                 departure_coordinates,
                 arrival_coordinates,
                 "DIRECT_TRIP",
-                color_usage=cmap["Plane"],
-                color_contrails=cmap["Contrails"],
             )
             trips.append(TripResult(name="PLANE", steps=[plane_result.step_data]))
             geometries += plane_result.geometries

--- a/backend/models.py
+++ b/backend/models.py
@@ -50,6 +50,8 @@ class TripStep:
 # OUTPUTS
 ######################
 
+TripType = Literal["MAIN_TRIP", "SECOND_TRIP", "DIRECT_TRIP"]
+
 
 @dataclass
 class TripStepGeometry:
@@ -60,6 +62,7 @@ class TripStepGeometry:
     length: float
     color: str
     country_label: str | None
+    trip_type: TripType
 
 
 @dataclass

--- a/backend/models.py
+++ b/backend/models.py
@@ -60,7 +60,6 @@ class TripStepGeometry:
     coordinates: list[list[float]]
     transport_means: str
     length: float
-    color: str
     country_label: str | None
     trip_type: TripType
 
@@ -73,7 +72,6 @@ class EmissionPart:
     ef_tot: float | None
     distance: float
     name: str
-    color: str
 
 
 @dataclass

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -11,48 +11,6 @@ carbon_intensity_electricity = gpd.read_file(
     "static/carbon_intensity_electricity.geojson",
 )
 
-
-####################
-#### COLORS ########
-####################
-
-# Select main colors
-l_colors_custom = [
-    # "#bfeef3"
-    "#b3eef5",
-    "#7de4f0",
-    "#4accdb",
-    "#148693",
-    "#27A4B2",
-    "#148693",
-    "#006773",
-]
-
-l_colors_direct = [
-    "#febc78",
-    "#E69138",
-    "#B45E06",
-    "#cd781f",
-    "#B45E06",
-]
-
-l_colors_alternative = [
-    # "#ffdfe4",
-    "#ffd1d9",
-    "#f9b5c1",
-    "#f299a9",
-    "#e5617a",
-    "#ec7d92",
-    "#e5617a",
-    "#df4562",
-]
-
-list_items = ["Bicycle", "Train", "Road", "Cons_infra", "Contrails", "Plane", "Ferry"]
-colors_custom = dict(zip(list_items, l_colors_custom))
-l_direct = ["Train", "Road", "Cons_infra", "Contrails", "Plane"]
-colors_direct = dict(zip(l_direct, l_colors_direct))
-colors_alternative = dict(zip(list_items, l_colors_alternative))
-
 # Geometries from API
 simplified = True
 if simplified:

--- a/backend/transport_bicycle.py
+++ b/backend/transport_bicycle.py
@@ -68,13 +68,11 @@ def bicycle_to_gdf(
     arrival_coords: tuple[float, float],
     trip_type: TripType,
     EF=EF_bicycle,
-    color="#ffffff",
     validate=val_perimeter,
 ) -> TripStepResult | None:
     """Parameters
         - departure_coords, arrival_coords
         - EF_bus, float emission factor for bike by pkm
-        - color, color in hex of path and bar chart
         - validate
 
     Return:
@@ -105,7 +103,6 @@ def bicycle_to_gdf(
                     kg_co2_eq=round(EF * route_length, 2),
                     distance=round(route_length),
                     ef_tot=EF,
-                    color=color,
                 ),
             ],
             path_length=round(route_length),
@@ -116,7 +113,6 @@ def bicycle_to_gdf(
                 coordinates=[[list(coord) for coord in route_geometry.coords]],
                 transport_means="bicycle",
                 length=route_length,
-                color=color,
                 country_label=None,
                 trip_type=trip_type,
             ),

--- a/backend/transport_bicycle.py
+++ b/backend/transport_bicycle.py
@@ -26,6 +26,7 @@ from models import (
     EmissionPart,
     TripStepGeometry,
     TripStepResult,
+    TripType,
 )
 from parameters import EF_bicycle, val_perimeter
 from utils import validate_geom
@@ -65,6 +66,7 @@ def find_bicycle(
 def bicycle_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
+    trip_type: TripType,
     EF=EF_bicycle,
     color="#ffffff",
     validate=val_perimeter,
@@ -116,6 +118,7 @@ def bicycle_to_gdf(
                 length=route_length,
                 color=color,
                 country_label=None,
+                trip_type=trip_type,
             ),
         ],
     )

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -92,13 +92,10 @@ def ecar_to_gdf(
     trip_type: TripType,
     passengers_nb=1,
     validate=val_perimeter,
-    color_usage="#ffffff",
-    color_cons="#ffffff",
 ):
     """Parameters
         - departure_coords, arrival_coords
         - validate
-        - colormap, list of colors
     return:
         - full dataframe for trains.
 
@@ -120,9 +117,6 @@ def ecar_to_gdf(
         real_path_length=route_length,
     )
 
-    # Add colors
-    gdf["colors"] = color_usage
-
     passengers_nb = int(passengers_nb)
     gdf["EF"] /= 1000.0  # Conversion in kg
 
@@ -136,7 +130,6 @@ def ecar_to_gdf(
         pd.DataFrame({
             "kgCO2eq": [route_length * EF_ecar["construction"] / passengers_nb],
             "EF": [EF_ecar["construction"]],
-            "colors": [color_cons],
             "NAME": ["construction"],
             "path_length": [route_length],
         }),
@@ -146,7 +139,7 @@ def ecar_to_gdf(
     gdf["length"] = str(int(route_length)) + "km (" + gdf["NAME"] + ")"
     gdf.reset_index(inplace=True)
 
-    geo_ecar = gdf[["colors", "label", "geometry", "path_length", "NAME"]].dropna(
+    geo_ecar = gdf[["label", "geometry", "path_length", "NAME"]].dropna(
         axis=0,
     )
 
@@ -156,14 +149,13 @@ def ecar_to_gdf(
             TripStepGeometry(
                 coordinates=[[list(coord) for coord in row["geometry"].coords]],
                 transport_means="Road",
-                color=color_usage,
                 length=row["path_length"],
                 country_label=row["NAME"],
                 trip_type=trip_type,
             ),
         )
 
-    emissions_data = gdf[["kgCO2eq", "colors", "NAME", "EF", "path_length"]].to_dict(
+    emissions_data = gdf[["kgCO2eq", "NAME", "EF", "path_length"]].to_dict(
         "records",
     )
 
@@ -171,7 +163,6 @@ def ecar_to_gdf(
         EmissionPart(
             name=emission_data["NAME"],
             kg_co2_eq=round(emission_data["kgCO2eq"], 2),
-            color=emission_data["colors"],
             ef_tot=emission_data["EF"],
             distance=round(emission_data["path_length"]),
         )
@@ -194,8 +185,6 @@ def ecar_to_gdf(
 def get_car_emissions(
     route_length: float,
     passengers_nb: str,
-    color_usage: str,
-    color_construction: str,
 ) -> list[EmissionPart]:
     if passengers_nb == "👍":  # Hitch-hiking
         EF_fuel = EF_car["fuel"] * 0.04
@@ -211,14 +200,12 @@ def get_car_emissions(
             kg_co2_eq=round(route_length * EF_construction, 2),
             ef_tot=EF_car["construction"],
             distance=round(route_length),
-            color=color_construction,
         ),
         EmissionPart(
             name="fuel",
             kg_co2_eq=round(route_length * EF_fuel, 2),
             ef_tot=EF_car["fuel"],
             distance=round(route_length),
-            color=color_usage,
         ),
     ]
 
@@ -227,8 +214,6 @@ def get_bus_emissions(
     route_length: float,
     EF_fuel: float,
     EF_construction: float,
-    color_usage: str,
-    color_construction: str,
 ) -> list[EmissionPart]:
     return [
         EmissionPart(
@@ -236,14 +221,12 @@ def get_bus_emissions(
             kg_co2_eq=round(route_length * EF_construction, 2),
             ef_tot=EF_construction,
             distance=round(route_length),
-            color=color_construction,
         ),
         EmissionPart(
             name="fuel",
             kg_co2_eq=round(route_length * EF_fuel, 2),
             ef_tot=EF_fuel,
             distance=round(route_length),
-            color=color_usage,
         ),
     ]
 
@@ -251,13 +234,11 @@ def get_bus_emissions(
 def get_road_geometry_data(
     route_length: float,
     route_geometry: LineString,
-    color_usage: str,
     trip_type: TripType,
 ):
     return TripStepGeometry(
         coordinates=[[list(coord) for coord in route_geometry.coords]],
         transport_means="Road",
-        color=color_usage,
         length=route_length,
         country_label=None,
         trip_type=trip_type,
@@ -270,8 +251,6 @@ def car_bus_to_gdf(
     EF_car=EF_car,
     EF_bus=EF_bus,
     validate=val_perimeter,
-    color_usage="#ffffff",
-    color_cons="#ffffff",
 ) -> CarBusResults | None:
     """ONLY FOR FIRST FORM (optimization).
 
@@ -280,7 +259,6 @@ def car_bus_to_gdf(
         - departure_coords, arrival_coords
         - EF_car, float emission factor for one car by km
         - EF_bus, float emission factor for bus by pkm
-        - color, color in hex of path and bar chart
         - validate
     return:
         - CarBusResults or None
@@ -299,23 +277,18 @@ def car_bus_to_gdf(
     road_geometry = get_road_geometry_data(
         route_length,
         route_geometry,
-        color_usage,
         "DIRECT_TRIP",
     )
 
     car_emissions = get_car_emissions(
         route_length,
         1,
-        color_usage,
-        color_cons,
     )
 
     bus_emissions = get_bus_emissions(
         route_length,
         EF_bus["fuel"],
         EF_bus["construction"],
-        color_usage,
-        color_cons,
     )
 
     return CarBusResults(
@@ -345,13 +318,10 @@ def bus_to_gdf(
     trip_type: TripType,
     EF_bus=EF_bus,
     validate=val_perimeter,
-    color_usage="#ffffff",
-    color_cons="#ffffff",
 ) -> TripStepResult | None:
     """Parameters
         - departure_coords, arrival_coords
         - EF_bus, float emission factor for bus by pkm
-        - color, color in hex of path and bar chart
         - validate
 
     Returns
@@ -372,15 +342,12 @@ def bus_to_gdf(
     road_geometry = get_road_geometry_data(
         route_length,
         route_geometry,
-        color_usage,
         trip_type,
     )
     emissions = get_bus_emissions(
         route_length,
         EF_bus["fuel"],
         EF_bus["construction"],
-        color_usage,
-        color_cons,
     )
 
     return TripStepResult(
@@ -402,13 +369,10 @@ def car_to_gdf(
     EF_car=EF_car,
     validate=val_perimeter,
     passengers_nb=1,
-    color_usage="#ffffff",
-    color_cons="#ffffff",
 ) -> TripStepResult | None:
     """Parameters
         - departure_coords, arrival_coords
         - EF_car, float emission factor for one car by km
-        - color, color in hex of path and bar chart
         - validate
         - nb, number of passenger in the car (used only for custom trip).
 
@@ -430,7 +394,6 @@ def car_to_gdf(
     geometry = get_road_geometry_data(
         route_length,
         route_geometry,
-        color_usage,
         trip_type,
     )
 
@@ -440,8 +403,6 @@ def car_to_gdf(
             emissions=get_car_emissions(
                 route_length,
                 passengers_nb,
-                color_usage,
-                color_cons,
             ),
             is_hitch_hike=passengers_nb == "👍",
             passengers_nb=passengers_nb,

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -29,6 +29,7 @@ from models import (
     EmissionPart,
     TripStepGeometry,
     TripStepResult,
+    TripType,
 )
 from parameters import (
     EF_bus,
@@ -88,6 +89,7 @@ def find_route(
 def ecar_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
+    trip_type: TripType,
     passengers_nb=1,
     validate=val_perimeter,
     color_usage="#ffffff",
@@ -157,6 +159,7 @@ def ecar_to_gdf(
                 color=color_usage,
                 length=row["path_length"],
                 country_label=row["NAME"],
+                trip_type=trip_type,
             ),
         )
 
@@ -249,6 +252,7 @@ def get_road_geometry_data(
     route_length: float,
     route_geometry: LineString,
     color_usage: str,
+    trip_type: TripType,
 ):
     return TripStepGeometry(
         coordinates=[[list(coord) for coord in route_geometry.coords]],
@@ -256,6 +260,7 @@ def get_road_geometry_data(
         color=color_usage,
         length=route_length,
         country_label=None,
+        trip_type=trip_type,
     )
 
 
@@ -291,7 +296,12 @@ def car_bus_to_gdf(
     ):
         return None
 
-    road_geometry = get_road_geometry_data(route_length, route_geometry, color_usage)
+    road_geometry = get_road_geometry_data(
+        route_length,
+        route_geometry,
+        color_usage,
+        "DIRECT_TRIP",
+    )
 
     car_emissions = get_car_emissions(
         route_length,
@@ -332,6 +342,7 @@ def car_bus_to_gdf(
 def bus_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
+    trip_type: TripType,
     EF_bus=EF_bus,
     validate=val_perimeter,
     color_usage="#ffffff",
@@ -358,7 +369,12 @@ def bus_to_gdf(
     ):
         return None
 
-    road_geometry = get_road_geometry_data(route_length, route_geometry, color_usage)
+    road_geometry = get_road_geometry_data(
+        route_length,
+        route_geometry,
+        color_usage,
+        trip_type,
+    )
     emissions = get_bus_emissions(
         route_length,
         EF_bus["fuel"],
@@ -382,6 +398,7 @@ def bus_to_gdf(
 def car_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
+    trip_type: TripType,
     EF_car=EF_car,
     validate=val_perimeter,
     passengers_nb=1,
@@ -410,7 +427,12 @@ def car_to_gdf(
     ):
         return None
 
-    geometry = get_road_geometry_data(route_length, route_geometry, color_usage)
+    geometry = get_road_geometry_data(
+        route_length,
+        route_geometry,
+        color_usage,
+        trip_type,
+    )
 
     return TripStepResult(
         step_data=CarStepData(

--- a/backend/transport_ferry.py
+++ b/backend/transport_ferry.py
@@ -218,12 +218,10 @@ def ferry_to_gdf(
     trip_type: TripType,
     EF=EF_ferry,
     options="none",
-    color_usage="#ffffff",
 ) -> TripStepResult:
     """Parameters
         - tag1, tag2
         - EF : emission factor in gCO2/pkm for ferry
-        - color : color for path and bar chart
     return:
         - full dataframe for ferry.
 
@@ -264,7 +262,6 @@ def ferry_to_gdf(
                     kg_co2_eq=round(EF * bird, 2),
                     ef_tot=EF,
                     distance=round(bird),
-                    color=color_usage,
                 ),
             ],
             path_length=round(bird),
@@ -276,7 +273,6 @@ def ferry_to_gdf(
                 coordinates=coordinates,
                 transport_means="ferry",
                 length=bird,
-                color=color_usage,
                 country_label=None,
                 trip_type=trip_type,
             ),
@@ -289,12 +285,10 @@ def sail_to_gdf(
     tag2,
     trip_type: TripType,
     EF=EF_sail,
-    color_usage="#ffffff",
 ) -> TripStepResult:
     """Parameters
         - tag1, tag2
         - EF : emission factor in gCO2/pkm for ferry
-        - color : color for path and bar chart
     return:
         - full dataframe for ferry.
 
@@ -326,7 +320,6 @@ def sail_to_gdf(
                     kg_co2_eq=round(EF * bird, 2),
                     ef_tot=EF,
                     distance=round(bird),
-                    color=color_usage,
                 ),
             ],
             path_length=round(bird),
@@ -337,7 +330,6 @@ def sail_to_gdf(
                 coordinates=coordinates,
                 transport_means="sail",
                 length=bird,
-                color=color_usage,
                 country_label=None,
                 trip_type=trip_type,
             ),

--- a/backend/transport_ferry.py
+++ b/backend/transport_ferry.py
@@ -33,6 +33,7 @@ from models import (
     SailStepData,
     TripStepGeometry,
     TripStepResult,
+    TripType,
 )
 from parameters import (
     EF_ferry,
@@ -214,6 +215,7 @@ def gdf_lines(start, end, add_canal=True):
 def ferry_to_gdf(
     tag1,
     tag2,
+    trip_type: TripType,
     EF=EF_ferry,
     options="none",
     color_usage="#ffffff",
@@ -276,12 +278,19 @@ def ferry_to_gdf(
                 length=bird,
                 color=color_usage,
                 country_label=None,
+                trip_type=trip_type,
             ),
         ],
     )
 
 
-def sail_to_gdf(tag1, tag2, EF=EF_sail, color_usage="#ffffff") -> TripStepResult:
+def sail_to_gdf(
+    tag1,
+    tag2,
+    trip_type: TripType,
+    EF=EF_sail,
+    color_usage="#ffffff",
+) -> TripStepResult:
     """Parameters
         - tag1, tag2
         - EF : emission factor in gCO2/pkm for ferry
@@ -330,6 +339,7 @@ def sail_to_gdf(tag1, tag2, EF=EF_sail, color_usage="#ffffff") -> TripStepResult
                 length=bird,
                 color=color_usage,
                 country_label=None,
+                trip_type=trip_type,
             ),
         ],
     )

--- a/backend/transport_plane.py
+++ b/backend/transport_plane.py
@@ -23,6 +23,7 @@ from models import (
     PlaneStepData,
     TripStepGeometry,
     TripStepResult,
+    TripType,
 )
 
 
@@ -105,6 +106,7 @@ def great_circle_geometry(
 def plane_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
+    trip_type: TripType,
     EF_plane=EF_plane,
     contrails=CONTRAILS_COEFF,
     holding=HOLD,
@@ -179,6 +181,7 @@ def plane_to_gdf(
                 length=route_length,
                 color=color_usage,
                 country_label=None,
+                trip_type=trip_type,
             ),
         ],
     )

--- a/backend/transport_plane.py
+++ b/backend/transport_plane.py
@@ -111,16 +111,12 @@ def plane_to_gdf(
     contrails=CONTRAILS_COEFF,
     holding=HOLD,
     detour=DETOUR_COEFF,
-    color_usage="#ffffff",
-    color_contrails="#ffffff",
 ) -> TripStepResult:
     """Parameters
         - departure_coords, arrival_coords
         - EF : emission factor in gCO2/pkm for plane depending on journey length
         - contrails : coefficient to apply to take into account non-CO2 effects
         - holding : additional CO2 emissions (kg) due to holding patterns
-        - color : color for path and bar chart
-        - color_contrails : color for non CO2-effects in bar chart
     return:
         - full dataframe for plane, geometry for CO2 only (optimization).
 
@@ -154,14 +150,12 @@ def plane_to_gdf(
                 kg_co2_eq=round(route_length_with_detour * CO2_factors + holding, 2),
                 ef_tot=CO2_factors,
                 distance=round(route_length_with_detour),
-                color=color_usage,
             ),
             EmissionPart(
                 name="contrails",
                 kg_co2_eq=round(route_length_with_detour * non_CO2_factors, 2),
                 ef_tot=non_CO2_factors,
                 distance=round(route_length_with_detour),
-                color=color_contrails,
             ),
         ],
         path_length=round(route_length),
@@ -179,7 +173,6 @@ def plane_to_gdf(
                 coordinates=[[list(coord) for coord in plane_geometry.coords]],
                 transport_means="Flight",
                 length=route_length,
-                color=color_usage,
                 country_label=None,
                 trip_type=trip_type,
             ),

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -31,6 +31,7 @@ from models import (
     TrainStepData,
     TripStepGeometry,
     TripStepResult,
+    TripType,
 )
 from parameters import (
     EF_train,
@@ -216,6 +217,7 @@ def find_train(
 def train_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
+    trip_type: TripType,
     perims=search_perimeter,
     EF_train=EF_train,
     validate=val_perimeter,
@@ -309,6 +311,7 @@ def train_to_gdf(
                     length=geo["path_length"],
                     color=geo["colors"],
                     country_label=geo["NAME"],
+                    trip_type=trip_type,
                 ),
             )
         elif type(geo["geometry"]) is MultiLineString:
@@ -322,6 +325,7 @@ def train_to_gdf(
                     length=geo["path_length"],
                     color=geo["colors"],
                     country_label=geo["NAME"],
+                    trip_type=trip_type,
                 ),
             )
         else:

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -221,9 +221,7 @@ def train_to_gdf(
     perims=search_perimeter,
     EF_train=EF_train,
     validate=val_perimeter,
-    color_usage="#ffffff",
-    color_infra="#ffffff",
-):  # charte_mollow
+):
     """Find the train path between 2 points and compute the emissions of the path.
 
     Parameters
@@ -231,7 +229,6 @@ def train_to_gdf(
         - departure_coords, arrival_coords
         - perims
         - validate
-        - colormap, list of colors
 
     Returns
     -------
@@ -278,27 +275,21 @@ def train_to_gdf(
     gdf["EF"] /= 1000.0  # Conversion in kg
     gdf["kgCO2eq"] = gdf["path_length"] * gdf["EF"]
 
-    gdf["colors"] = color_usage
-
     # Add infra emissions
     gdf = pd.concat([
         pd.DataFrame({
             "kgCO2eq": [train_dist * EF_train["infra"]],
             "EF": [EF_train["infra"]],
-            "colors": [color_infra],
             "NAME": ["infra"],
             "path_length": [train_dist],
         }),
         gdf,
     ])
 
-    # Add infra
     gdf.reset_index(inplace=True)
 
     geo_train = (
-        gdf[["colors", "geometry", "path_length", "NAME"]]
-        .dropna(axis=0)
-        .to_dict("records")
+        gdf[["geometry", "path_length", "NAME"]].dropna(axis=0).to_dict("records")
     )
 
     geometries = []
@@ -309,7 +300,6 @@ def train_to_gdf(
                     coordinates=[[list(coord) for coord in geo["geometry"].coords]],
                     transport_means="Railway",
                     length=geo["path_length"],
-                    color=geo["colors"],
                     country_label=geo["NAME"],
                     trip_type=trip_type,
                 ),
@@ -323,7 +313,6 @@ def train_to_gdf(
                     coordinates=coordinates,
                     transport_means="Railway",
                     length=geo["path_length"],
-                    color=geo["colors"],
                     country_label=geo["NAME"],
                     trip_type=trip_type,
                 ),
@@ -331,14 +320,13 @@ def train_to_gdf(
         else:
             raise GeometryRecognitionError
 
-    emissions_data = gdf[["kgCO2eq", "colors", "NAME", "EF", "path_length"]].to_dict(
+    emissions_data = gdf[["kgCO2eq", "NAME", "EF", "path_length"]].to_dict(
         "records",
     )
     emissions = [
         EmissionPart(
             name=emission_data["NAME"],
             kg_co2_eq=round(emission_data["kgCO2eq"], 2),
-            color=emission_data["colors"],
             ef_tot=emission_data["EF"],
             distance=round(emission_data["path_length"]),
         )

--- a/frontend/src/MainView/helpers/simulationContext/formatResponse.ts
+++ b/frontend/src/MainView/helpers/simulationContext/formatResponse.ts
@@ -9,6 +9,49 @@ import {
 } from "types";
 import { round } from "utils";
 
+type ColorMap = {
+  usage: string;
+  contrails: string;
+  upstream: string;
+};
+
+const MAIN_COLORS = {
+  contrails: "#7de4f0",
+  usage: "#4accdb",
+  upstream: "#006773",
+};
+
+const ALTERNATIVE_COLORS = {
+  contrails: "#ffd1d9",
+  usage: "#f299a9",
+  upstream: "#df4562",
+};
+
+const DIRECT_COLORS = {
+  contrails: "#febc78",
+  usage: "#E69138",
+  upstream: "#B45E06",
+};
+
+const getColorMap = (tripName: string) => {
+  if (tripName === "MAIN_TRIP") return MAIN_COLORS;
+  if (tripName === "SECOND_TRIP") return ALTERNATIVE_COLORS;
+  return DIRECT_COLORS;
+};
+
+const getEmissionColor = (colorMap: ColorMap, emissionSouce: string) => {
+  switch (emissionSouce) {
+    case "contrails":
+      return colorMap.contrails;
+    case "construction":
+    case "infra":
+    case "bikeBuild":
+      return colorMap.upstream;
+    default:
+      return colorMap.usage;
+  }
+};
+
 export const formatResponse = (
   inputs: { mainSteps: Step[]; altSteps?: Step[] },
   data: ApiResponse,
@@ -25,6 +68,8 @@ export const formatResponse = (
     const formattedSteps: TripStep[] = [];
     let totalEmissions = 0;
 
+    const colorMap = getColorMap(trip.name);
+
     const inputSteps =
       trip.name !== "SECOND_TRIP"
         ? inputs.mainSteps
@@ -39,7 +84,7 @@ export const formatResponse = (
         stepEmissions += emission.kg_co2_eq;
         emissionParts.push({
           emissionSource: emission.name,
-          color: emission.color,
+          color: getEmissionColor(colorMap, emission.name),
           emissions: emission.kg_co2_eq,
           distance: emission.distance,
           coefficient: emission.ef_tot,

--- a/frontend/src/MainView/helpers/simulationContext/formatResponse.ts
+++ b/frontend/src/MainView/helpers/simulationContext/formatResponse.ts
@@ -132,13 +132,15 @@ export const formatResponse = (
         ? "road_with_country"
         : geometry.transport_means.toLowerCase();
 
+    const colorMap = getColorMap(geometry.trip_type);
+
     return geometry.coordinates.map((coords) => ({
       label: i18next.t(`chart.paths.${transportMeans}_with_details`, {
         countryLabel: geometry.country_label,
         length: Math.round(geometry.length),
       }),
       transportMeans: geometry.transport_means,
-      color: geometry.color,
+      color: colorMap.usage,
       coordinates: coords,
     }));
   });

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,5 +1,9 @@
 export const thumbUp = "👍";
 
+/*****************
+ *  INPUT TYPES  *
+ *****************/
+
 export enum TRIP_TYPE {
   MAIN = "main",
   ALTERNATIVE = "alternative",
@@ -24,8 +28,6 @@ export enum Transport {
   ferry = "ferry",
   bicycle = "bicycle",
   sail = "sail",
-  myTrip = "myTrip",
-  otherTrip = "otherTrip",
 }
 
 export enum FerryOptions {
@@ -34,6 +36,10 @@ export enum FerryOptions {
   vehicle = "vehicle",
   cabinVehicle = "cabinVehicle",
 }
+
+/*****************
+ *  API TYPES    *
+ *****************/
 
 type TripStepGeometry = {
   color: string;
@@ -103,45 +109,14 @@ type TripResult = {
 };
 
 export type ApiResponse = {
-  my_trip: string;
-  direct_trip?: string;
-  alternative_trip?: string;
   error: string;
   geometries: TripStepGeometry[];
   trips: TripResult[];
 };
 
-export type MyTripData = {
-  NAME: string;
-  colors: string;
-  kgCO2eq: number;
-  "Mean of Transport": Transport;
-  step: number;
-};
-
-export type DirectTripData = {
-  ISO2: string;
-  NAME: string;
-  EF_tot: number;
-  colors: string;
-  path_length: number;
-  kgCO2eq: number;
-  "Mean of Transport": Transport;
-  Type: string;
-};
-
-export enum EmissionsCategory {
-  infra = "infra",
-  construction = "construction",
-  fuel = "fuel",
-  kerosene = "kerosene",
-  contrails = "contrails",
-  bikeBuild = "bikeBuild",
-  none = "none",
-  cabin = "cabin",
-  vehicle = "vehicle",
-  cabinVehicle = "cabinVehicle",
-}
+/**************************
+ * FRONTEND OUTPUT TYPES  *
+ ***************************/
 
 export type Trip = {
   steps: TripStep[];

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -42,7 +42,7 @@ export enum FerryOptions {
  *****************/
 
 type TripStepGeometry = {
-  color: string;
+  trip_type: "MAIN_TRIP" | "SECOND_TRIP" | "DIRECT_TRIP";
   coordinates: [number, number][][];
   transport_means: string;
   length: number;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -58,7 +58,6 @@ type TripResult = {
       name: string;
       ef_tot: number;
       kg_co2_eq: number;
-      color: string;
       distance: number;
     }[];
   } & (


### PR DESCRIPTION
The colors of each emission part or of each geometry were determined in the backend. Move this logic to the frontend, since the backend should actually not take care of UI details.