### PR TITLE
🧹 back: simplify main functions arguments  by using internal constants

### DIFF
--- a/backend/backend.py
+++ b/backend/backend.py
@@ -32,9 +32,7 @@ from models import (
     TripStepGeometry,
     TripType,
 )
-from parameters import (
-    min_plane_dist,
-)
+from parameters import PLANE_MIN_DISTANCE
 from transport_bicycle import bicycle_to_gdf
 from transport_car import (
     bus_to_gdf,
@@ -210,7 +208,7 @@ def compute_direct_trips_emissions(inputs: list[TripStep]):
     if transport_means != "plane":
         bird_path = LineString([departure_coordinates, arrival_coordinates])
         bird_distance = Geod(ellps="WGS84").geometry_length(bird_path) / 1e3
-        if bird_distance > min_plane_dist:
+        if bird_distance > PLANE_MIN_DISTANCE:
             plane_result = plane_to_gdf(
                 departure_coordinates,
                 arrival_coordinates,

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -11,13 +11,6 @@ carbon_intensity_electricity = gpd.read_file(
     "static/carbon_intensity_electricity.geojson",
 )
 
-# Geometries from API
-simplified = True
-if simplified:
-    train_s, train_t, route_s = "simplified", "1", "simplified"
-else:
-    train_s, train_t, route_s = "full", "0", "full"
-
 # Validation perimeter
 val_perimeter = 100  # km
 

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -11,11 +11,5 @@ carbon_intensity_electricity = gpd.read_file(
     "static/carbon_intensity_electricity.geojson",
 )
 
-
-##########
-## Plane##
-##########
-
-
-# Min distance for plane comparison
-min_plane_dist = 300  # km
+# Minimun distance for plane comparison
+PLANE_MIN_DISTANCE = 300  # km

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -12,10 +12,6 @@ carbon_intensity_electricity = gpd.read_file(
 )
 
 
-# Threshold for unmatched train geometries (sea)
-sea_threshold = 5  # km
-
-
 ##########
 ## Plane##
 ##########

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -14,8 +14,6 @@ carbon_intensity_electricity = gpd.read_file(
 # Validation perimeter
 val_perimeter = 100  # km
 
-# Search areas
-search_perimeter = [0.2, 5]  # km
 
 # Threshold for unmatched train geometries (sea)
 sea_threshold = 5  # km

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -11,9 +11,6 @@ carbon_intensity_electricity = gpd.read_file(
     "static/carbon_intensity_electricity.geojson",
 )
 
-# Validation perimeter
-val_perimeter = 100  # km
-
 
 # Threshold for unmatched train geometries (sea)
 sea_threshold = 5  # km

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -5,7 +5,7 @@
 import geopandas as gpd
 
 
-# Load  world datasets
+# Load world datasets
 train_intensity = gpd.read_file("static/train_intensity.geojson")
 carbon_intensity_electricity = gpd.read_file(
     "static/carbon_intensity_electricity.geojson",
@@ -27,38 +27,6 @@ search_perimeter = [0.2, 5]  # km
 # Threshold for unmatched train geometries (sea)
 sea_threshold = 5  # km
 
-# Emission factors kg/pkm
-EF_car = {
-    "construction": 0.0256,
-    "fuel": 0.192,  # total : .2176
-    "infra": 0.0007,
-}
-EF_ecar = {
-    "construction": 0.0836,
-    "fuel": 0.187,  # kWh / km
-    "infra": 0.0007,
-}
-EF_bus = {
-    "construction": 0.00442,
-    "fuel": 0.025,  # total .02942
-    "infra": 0.0007,
-}
-
-EF_train = {
-    "construction": 0.0006,
-    "infra": 0.0065,
-}
-
-EF_bicycle = 0.005
-
-EF_ferry = {
-    "Cabin": 0.11,
-    "Seat": 0.008,
-    "Base": 0.08,
-    "Car": 0.114,
-}
-
-EF_sail = 0.069
 
 ##########
 ## Plane##

--- a/backend/transport_bicycle.py
+++ b/backend/transport_bicycle.py
@@ -29,7 +29,7 @@ from models import (
     TripType,
 )
 from parameters import val_perimeter
-from utils import validate_geom
+from utils import validate_geometry
 
 
 # Bicycle manufacturing emissions (kgCO2e/km).
@@ -99,7 +99,7 @@ def bicycle_to_gdf(
         arrival_coords,
     )
 
-    if not success or not validate_geom(
+    if not success or not validate_geometry(
         departure_coords,
         arrival_coords,
         route_geometry,

--- a/backend/transport_bicycle.py
+++ b/backend/transport_bicycle.py
@@ -28,7 +28,6 @@ from models import (
     TripStepResult,
     TripType,
 )
-from parameters import val_perimeter
 from utils import validate_geometry
 
 
@@ -83,11 +82,9 @@ def bicycle_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    validate=val_perimeter,
 ) -> TripStepResult | None:
     """Parameters
         - departure_coords, arrival_coords
-        - validate
 
     Return:
     ------
@@ -103,7 +100,6 @@ def bicycle_to_gdf(
         departure_coords,
         arrival_coords,
         route_geometry,
-        validate,
     ):
         return None
 

--- a/backend/transport_bicycle.py
+++ b/backend/transport_bicycle.py
@@ -28,9 +28,14 @@ from models import (
     TripStepResult,
     TripType,
 )
-from parameters import EF_bicycle, val_perimeter
+from parameters import val_perimeter
 from utils import validate_geom
 
+
+# Bicycle manufacturing emissions (kgCO2e/km).
+# Source: European Cyclists' Federation, 2024.
+# https://ecf.com/news-and-events/news/how-much-co2-does-cycling-really-save
+EF_BICYCLE_MANUFACTURING = 0.005
 
 API_KEY = os.environ.get("BICYCLE_API_KEY")
 OPEN_ROUTE_SERVICE = "https://api.openrouteservice.org/v2/directions/cycling-regular"
@@ -78,12 +83,10 @@ def bicycle_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    EF=EF_bicycle,
     validate=val_perimeter,
 ) -> TripStepResult | None:
     """Parameters
         - departure_coords, arrival_coords
-        - EF_bus, float emission factor for bike by pkm
         - validate
 
     Return:
@@ -110,13 +113,13 @@ def bicycle_to_gdf(
             emissions=[
                 EmissionPart(
                     name="bikeBuild",
-                    kg_co2_eq=round(EF * route_length, 2),
+                    kg_co2_eq=round(EF_BICYCLE_MANUFACTURING * route_length, 2),
                     distance=round(route_length),
-                    ef_tot=EF,
+                    ef_tot=EF_BICYCLE_MANUFACTURING,
                 ),
             ],
             path_length=round(route_length),
-            coeff_upstream=EF,
+            coeff_upstream=EF_BICYCLE_MANUFACTURING,
         ),
         geometries=[
             TripStepGeometry(

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -31,7 +31,6 @@ from models import (
     TripStepResult,
     TripType,
 )
-from parameters import val_perimeter
 from utils import split_path_by_country, validate_geometry
 
 
@@ -92,11 +91,9 @@ def ecar_to_gdf(
     arrival_coords: tuple[float, float],
     trip_type: TripType,
     passengers_nb=1,
-    validate=val_perimeter,
 ):
     """Parameters
         - departure_coords, arrival_coords
-        - validate
     return:
         - full dataframe for trains.
 
@@ -107,7 +104,6 @@ def ecar_to_gdf(
         departure_coords,
         arrival_coords,
         route_geometry,
-        validate,
     ):
         return None
 
@@ -256,16 +252,12 @@ class CarBusResults:
 def car_bus_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
-    validate=val_perimeter,
 ) -> CarBusResults | None:
     """ONLY FOR FIRST FORM (optimization).
 
     Parameters
     ----------
         - departure_coords, arrival_coords
-        - EF_car, float emission factor for one car by km
-        - EF_bus, float emission factor for bus by pkm
-        - validate
     return:
         - CarBusResults or None
 
@@ -276,7 +268,6 @@ def car_bus_to_gdf(
         departure_coords,
         arrival_coords,
         route_geometry,
-        validate,
     ):
         return None
 
@@ -320,12 +311,10 @@ def bus_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    validate=val_perimeter,
 ) -> TripStepResult | None:
     """Parameters
         - departure_coords, arrival_coords
         - EF_bus, float emission factor for bus by pkm
-        - validate
 
     Returns
     -------
@@ -338,7 +327,6 @@ def bus_to_gdf(
         departure_coords,
         arrival_coords,
         route_geometry,
-        validate,
     ):
         return None
 
@@ -367,13 +355,11 @@ def car_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    validate=val_perimeter,
     passengers_nb=1,
 ) -> TripStepResult | None:
     """Parameters
         - departure_coords, arrival_coords
         - EF_car, float emission factor for one car by km
-        - validate
         - nb, number of passenger in the car (used only for custom trip).
 
     Returns
@@ -387,7 +373,6 @@ def car_to_gdf(
         departure_coords,
         arrival_coords,
         route_geometry,
-        validate,
     ):
         return None
 

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -32,25 +32,29 @@ from models import (
     TripType,
 )
 from parameters import (
-    EF_bus,
-    EF_car,
-    EF_ecar,
     route_s,
     val_perimeter,
 )
 from utils import split_path_by_country, validate_geom as validate_geometry
 
 
-@dataclass
-class CarBusResults:
-    """Dataclass for car and bus emissions and road geometry."""
-
-    geometries: list[TripStepGeometry]
-    bus_step_data: BusStepData
-    car_step_data: CarStepData
-
-
 OSM_ROUTER_URL = "http://router.project-osrm.org/route/v1/driving"
+
+
+# Car emissions factors (kgCO2e / km).
+# Source: ADEME Base Carbone (2024)
+EF_CAR_CONSTRUCTION = 0.0256
+EF_CAR_FUEL = 0.192
+
+# Bus emissions factors (kgCO2e / passenger.km).
+# Source: ADEME Base Carbone (2024)
+EF_BUS_CONSTRUCTION = 0.00442
+EF_BUS_FUEL = 0.025
+
+# Electric car emissions factors (kgCO2e / km).
+EF_ECAR_CONSTRUCTION = 0.0836
+# Source: EV Database (2024) - https://ev-database.org/cheatsheet/energy-consumption-electric-car
+EF_ECAR_FUEL = 0.187
 
 
 def find_route(
@@ -121,15 +125,15 @@ def ecar_to_gdf(
     gdf["EF"] /= 1000.0  # Conversion in kg
 
     gdf["EF_tot"] = (
-        gdf["EF"] * EF_ecar["fuel"] * (1 + 0.04 * (passengers_nb - 1)) / passengers_nb
+        gdf["EF"] * EF_ECAR_FUEL * (1 + 0.04 * (passengers_nb - 1)) / passengers_nb
     )
     gdf["kgCO2eq"] = gdf["path_length"] * gdf["EF_tot"]
 
     # Add infra and construction
     gdf = pd.concat([
         pd.DataFrame({
-            "kgCO2eq": [route_length * EF_ecar["construction"] / passengers_nb],
-            "EF": [EF_ecar["construction"]],
+            "kgCO2eq": [route_length * EF_ECAR_CONSTRUCTION / passengers_nb],
+            "EF": [EF_ECAR_CONSTRUCTION],
             "NAME": ["construction"],
             "path_length": [route_length],
         }),
@@ -175,8 +179,8 @@ def ecar_to_gdf(
             emissions=emissions,
             path_length=round(route_length),
             passengers_nb=passengers_nb,
-            coeff_upstream=EF_ecar["construction"],
-            coeff_fuel=EF_ecar["fuel"],
+            coeff_upstream=EF_ECAR_CONSTRUCTION,
+            coeff_fuel=EF_ECAR_FUEL,
         ),
         geometries=geometries,
     )
@@ -187,24 +191,24 @@ def get_car_emissions(
     passengers_nb: str,
 ) -> list[EmissionPart]:
     if passengers_nb == "👍":  # Hitch-hiking
-        EF_fuel = EF_car["fuel"] * 0.04
+        EF_fuel = EF_CAR_FUEL * 0.04
         EF_construction = 0
     else:
         passengers_nb = int(passengers_nb)
-        EF_fuel = EF_car["fuel"] * (1 + 0.04 * (passengers_nb - 1)) / passengers_nb
-        EF_construction = EF_car["construction"] / passengers_nb
+        EF_fuel = EF_CAR_FUEL * (1 + 0.04 * (passengers_nb - 1)) / passengers_nb
+        EF_construction = EF_CAR_CONSTRUCTION / passengers_nb
 
     return [
         EmissionPart(
             name="construction",
             kg_co2_eq=round(route_length * EF_construction, 2),
-            ef_tot=EF_car["construction"],
+            ef_tot=EF_CAR_CONSTRUCTION,
             distance=round(route_length),
         ),
         EmissionPart(
             name="fuel",
             kg_co2_eq=round(route_length * EF_fuel, 2),
-            ef_tot=EF_car["fuel"],
+            ef_tot=EF_CAR_FUEL,
             distance=round(route_length),
         ),
     ]
@@ -212,20 +216,18 @@ def get_car_emissions(
 
 def get_bus_emissions(
     route_length: float,
-    EF_fuel: float,
-    EF_construction: float,
 ) -> list[EmissionPart]:
     return [
         EmissionPart(
             name="construction",
-            kg_co2_eq=round(route_length * EF_construction, 2),
-            ef_tot=EF_construction,
+            kg_co2_eq=round(route_length * EF_BUS_CONSTRUCTION, 2),
+            ef_tot=EF_BUS_CONSTRUCTION,
             distance=round(route_length),
         ),
         EmissionPart(
             name="fuel",
-            kg_co2_eq=round(route_length * EF_fuel, 2),
-            ef_tot=EF_fuel,
+            kg_co2_eq=round(route_length * EF_BUS_FUEL, 2),
+            ef_tot=EF_BUS_FUEL,
             distance=round(route_length),
         ),
     ]
@@ -245,11 +247,18 @@ def get_road_geometry_data(
     )
 
 
+@dataclass
+class CarBusResults:
+    """Dataclass for car and bus emissions and road geometry."""
+
+    geometries: list[TripStepGeometry]
+    bus_step_data: BusStepData
+    car_step_data: CarStepData
+
+
 def car_bus_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
-    EF_car=EF_car,
-    EF_bus=EF_bus,
     validate=val_perimeter,
 ) -> CarBusResults | None:
     """ONLY FOR FIRST FORM (optimization).
@@ -287,8 +296,6 @@ def car_bus_to_gdf(
 
     bus_emissions = get_bus_emissions(
         route_length,
-        EF_bus["fuel"],
-        EF_bus["construction"],
     )
 
     return CarBusResults(
@@ -297,8 +304,8 @@ def car_bus_to_gdf(
             transport="bus",
             emissions=bus_emissions,
             path_length=round(route_length),
-            coeff_upstream=EF_bus["fuel"],
-            coeff_fuel=EF_bus["construction"],
+            coeff_upstream=EF_BUS_CONSTRUCTION,
+            coeff_fuel=EF_BUS_FUEL,
         ),
         car_step_data=CarStepData(
             transport="car",
@@ -306,8 +313,8 @@ def car_bus_to_gdf(
             path_length=round(route_length),
             passengers_nb=1,
             is_hitch_hike=False,
-            coeff_upstream=EF_car["fuel"],
-            coeff_fuel=EF_car["construction"],
+            coeff_upstream=EF_CAR_CONSTRUCTION,
+            coeff_fuel=EF_CAR_FUEL,
         ),
     )
 
@@ -316,7 +323,6 @@ def bus_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    EF_bus=EF_bus,
     validate=val_perimeter,
 ) -> TripStepResult | None:
     """Parameters
@@ -346,8 +352,6 @@ def bus_to_gdf(
     )
     emissions = get_bus_emissions(
         route_length,
-        EF_bus["fuel"],
-        EF_bus["construction"],
     )
 
     return TripStepResult(
@@ -355,8 +359,8 @@ def bus_to_gdf(
             transport="bus",
             emissions=emissions,
             path_length=round(route_length),
-            coeff_upstream=EF_bus["construction"],
-            coeff_fuel=EF_bus["fuel"],
+            coeff_upstream=EF_BUS_CONSTRUCTION,
+            coeff_fuel=EF_BUS_FUEL,
         ),
         geometries=[road_geometry],
     )
@@ -366,7 +370,6 @@ def car_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    EF_car=EF_car,
     validate=val_perimeter,
     passengers_nb=1,
 ) -> TripStepResult | None:
@@ -407,8 +410,8 @@ def car_to_gdf(
             is_hitch_hike=passengers_nb == "👍",
             passengers_nb=passengers_nb,
             path_length=round(route_length),
-            coeff_upstream=EF_car["construction"],
-            coeff_fuel=EF_car["fuel"],
+            coeff_upstream=EF_CAR_CONSTRUCTION,
+            coeff_fuel=EF_CAR_FUEL,
         ),
         geometries=[geometry],
     )

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -31,10 +31,7 @@ from models import (
     TripStepResult,
     TripType,
 )
-from parameters import (
-    route_s,
-    val_perimeter,
-)
+from parameters import val_perimeter
 from utils import split_path_by_country, validate_geom as validate_geometry
 
 
@@ -73,7 +70,7 @@ def find_route(
 
     """
     response = requests.get(
-        f"{OSM_ROUTER_URL}/{departure_coords[0]},{departure_coords[1]};{arrival_coords[0]},{arrival_coords[1]}?overview={route_s}&geometries=geojson",
+        f"{OSM_ROUTER_URL}/{departure_coords[0]},{departure_coords[1]};{arrival_coords[0]},{arrival_coords[1]}?overview=simplified&geometries=geojson",
     )
 
     if response.status_code != HTTPStatus.OK:

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -32,7 +32,7 @@ from models import (
     TripType,
 )
 from parameters import val_perimeter
-from utils import split_path_by_country, validate_geom as validate_geometry
+from utils import split_path_by_country, validate_geometry
 
 
 OSM_ROUTER_URL = "http://router.project-osrm.org/route/v1/driving"

--- a/backend/transport_ferry.py
+++ b/backend/transport_ferry.py
@@ -36,10 +36,22 @@ from models import (
     TripType,
 )
 from parameters import (
-    EF_ferry,
-    EF_sail,
     train_intensity,
 )
+
+
+# Ferry emissions factors (kgCO2e / passenger.km).
+# Source: Future.eco, analysis by Maël Thomas-Quillévéré
+# https://futur.eco/documentation/transport/ferry/empreinte-par-km-volume
+
+EF_FERRY_CABIN = 0.11
+EF_FERRY_SEAT = 0.008
+EF_FERRY_BASE = 0.08
+EF_FERRY_CAR = 0.114
+
+# Sailboat emissions factor (kgCO2e / passenger.km).
+# Source: Sailcoop
+EF_SAIL = 0.069
 
 
 def get_shortest_path(line_gdf, start, end):
@@ -209,7 +221,6 @@ def ferry_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    EF=EF_ferry,
     options="none",
 ) -> TripStepResult:
     """Parameters
@@ -230,13 +241,13 @@ def ferry_to_gdf(
 
     # Compute the good emission factor
     if options == "none":
-        EF = EF["Seat"] + EF["Base"]
+        EF = EF_FERRY_SEAT + EF_FERRY_BASE
     elif options == "cabin":
-        EF = EF["Cabin"] + EF["Base"]
+        EF = EF_FERRY_CABIN + EF_FERRY_BASE
     elif options == "vehicle":
-        EF = EF["Car"] + EF["Seat"] + EF["Base"]
+        EF = EF_FERRY_CAR + EF_FERRY_SEAT + EF_FERRY_BASE
     elif options == "cabinVehicle":
-        EF = EF["Car"] + EF["Cabin"] + EF["Base"]
+        EF = EF_FERRY_CAR + EF_FERRY_CABIN + EF_FERRY_BASE
 
     coordinates = []
     for l in geom.geoms:
@@ -276,7 +287,6 @@ def sail_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    EF=EF_sail,
 ) -> TripStepResult:
     """Parameters
         - departure_coords, arrival_coords
@@ -308,13 +318,13 @@ def sail_to_gdf(
             emissions=[
                 EmissionPart(
                     name="Usage",
-                    kg_co2_eq=round(EF * bird, 2),
-                    ef_tot=EF,
+                    kg_co2_eq=round(EF_SAIL * bird, 2),
+                    ef_tot=EF_SAIL,
                     distance=round(bird),
                 ),
             ],
             path_length=round(bird),
-            coeff_total=EF,
+            coeff_total=EF_SAIL,
         ),
         geometries=[
             TripStepGeometry(

--- a/backend/transport_plane.py
+++ b/backend/transport_plane.py
@@ -15,6 +15,8 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
+from dataclasses import dataclass
+
 from pyproj import Geod
 from shapely.geometry import LineString
 
@@ -27,35 +29,53 @@ from models import (
 )
 
 
-EF_plane = {
-    "short": {
-        "construction": 0.00038,
-        "upstream": 0.0242,
-        "combustion": 0.117,
-        "infra": 0.0003,
-    },
-    "medium": {
-        "construction": 0.00036,
-        "upstream": 0.0176,
-        "combustion": 0.0848,
-        "infra": 0.0003,
-    },
-    "long": {
-        "construction": 0.00026,
-        "upstream": 0.0143,
-        "combustion": 0.0687,
-        "infra": 0.0003,
-    },
-}
-
-
 # Number of points in plane geometry
 POINTS_NB = 100
 
-# Additional emissions from plane
-CONTRAILS_COEFF = 2
-HOLD = 3.81  # kg/p
+
+@dataclass(frozen=True)
+class PlaneEmissionFactors:
+    """Dataclass for plane emission factors. Values depend on the length of the flight."""
+
+    construction: float
+    upstream: float
+    combustion: float
+    infra: float
+
+
+# Plane emissions factors (kgCO2e / passenger.km)
+# SHORT < 1000km < MEDIUM < 3500km < LONG
+# Source: ADEME Base Carbone (2024)
+EF_PLANE_SHORT = PlaneEmissionFactors(
+    construction=0.00038,
+    upstream=0.0242,
+    combustion=0.117,
+    infra=0.0003,
+)
+EF_PLANE_MEDIUM = PlaneEmissionFactors(
+    construction=0.00036,
+    upstream=0.0176,
+    combustion=0.0848,
+    infra=0.0003,
+)
+EF_PLANE_LONG = PlaneEmissionFactors(
+    construction=0.00026,
+    upstream=0.0143,
+    combustion=0.0687,
+    infra=0.0003,
+)
+
+# Source: https://www.sciencedirect.com/science/article/pii/S0966692318305544
 DETOUR_COEFF = 1.076
+
+# Additional CO2 emissions (kg) due to holding patterns
+# Source: ATMOSFAIR
+# https://www.atmosfair.de/wp-content/uploads/flight-emissionscalculator-documentation-calculationmethodology.pdf
+HOLD = 3.81  # kg/p
+
+# Coefficient to apply to take into account non-CO2 effects
+# Sources: ADEME and IPCC
+CONTRAILS_COEFF = 2
 
 
 def great_circle_geometry(
@@ -107,16 +127,9 @@ def plane_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    EF_plane=EF_plane,
-    contrails=CONTRAILS_COEFF,
-    holding=HOLD,
-    detour=DETOUR_COEFF,
 ) -> TripStepResult:
     """Parameters
         - departure_coords, arrival_coords
-        - EF : emission factor in gCO2/pkm for plane depending on journey length
-        - contrails : coefficient to apply to take into account non-CO2 effects
-        - holding : additional CO2 emissions (kg) due to holding patterns
     return:
         - full dataframe for plane, geometry for CO2 only (optimization).
 
@@ -128,26 +141,24 @@ def plane_to_gdf(
     )
 
     # Different emission factors depending on the trip length
+    emissions_factors = EF_PLANE_LONG
     if route_length < 1000:
-        trip_category = "short"
+        emissions_factors = EF_PLANE_SHORT
     elif route_length < 3500:
-        trip_category = "medium"
-    else:
-        trip_category = "long"
+        emissions_factors = EF_PLANE_MEDIUM
 
     # detour coeffient
-    route_length_with_detour = route_length * detour
+    route_length_with_detour = route_length * DETOUR_COEFF
 
-    emissions_factors = EF_plane[trip_category]
-    CO2_factors = emissions_factors["combustion"] + emissions_factors["upstream"]
-    non_CO2_factors = emissions_factors["combustion"] * contrails
+    CO2_factors = emissions_factors.combustion + emissions_factors.upstream
+    non_CO2_factors = emissions_factors.combustion * CONTRAILS_COEFF
 
     step_data = PlaneStepData(
         transport="plane",
         emissions=[
             EmissionPart(
                 name="kerosene",
-                kg_co2_eq=round(route_length_with_detour * CO2_factors + holding, 2),
+                kg_co2_eq=round(route_length_with_detour * CO2_factors + HOLD, 2),
                 ef_tot=CO2_factors,
                 distance=round(route_length_with_detour),
             ),
@@ -159,11 +170,11 @@ def plane_to_gdf(
             ),
         ],
         path_length=round(route_length),
-        coeff_path_detour=detour,
-        coeff_contrails=contrails,
-        coeff_fuel=emissions_factors["combustion"],
-        coeff_upstream=emissions_factors["upstream"],
-        holding=holding,
+        coeff_path_detour=DETOUR_COEFF,
+        coeff_contrails=CONTRAILS_COEFF,
+        coeff_fuel=emissions_factors.combustion,
+        coeff_upstream=emissions_factors.upstream,
+        holding=HOLD,
     )
 
     return TripStepResult(

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -33,10 +33,7 @@ from models import (
     TripStepResult,
     TripType,
 )
-from parameters import (
-    search_perimeter,
-    val_perimeter,
-)
+from parameters import val_perimeter
 from utils import (
     kilometer_to_degree,
     split_path_by_country,
@@ -60,7 +57,7 @@ def flatten_list_of_tuples(lst):
     return [item for tup in lst for item in tup[::-1]]
 
 
-def find_nearest(lon, lat, perim):
+def find_nearest(lon, lat, search_perimeter: float):
     """This function find the nearest node for train raiway in the OSM network using Overpass API
     parameters:
         - lon, lat : coordinates in degree of the point
@@ -69,7 +66,9 @@ def find_nearest(lon, lat, perim):
         - new coordinates(lat, lon).
     """
     # Extend the area around the point
-    buff = list(Point(lon, lat).buffer(kilometer_to_degree(perim)).exterior.coords)
+    buff = list(
+        Point(lon, lat).buffer(kilometer_to_degree(search_perimeter)).exterior.coords,
+    )
     # Request Overpass API turbo data :
     l = flatten_list_of_tuples(buff)
 
@@ -105,7 +104,6 @@ def find_nearest(lon, lat, perim):
 def extend_search(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
-    perims,
 ):
     """Function to use when the train path is not found directly by the API.
     We search for nearby coordinates and request it again.
@@ -113,41 +111,43 @@ def extend_search(
     Parameters
     ----------
         - departure_coords, arrival_coords : list or tuple like with coordinates (lon, lat)
-        - perims : list-like ; perimeters to search for with overpass API
     return:
         - gdf (geoseries)
         - success (bool)
 
     """
+    SEARCH_PERIMETERS = [0.2, 5]  # km
+
     # We extend the search progressively
-    for perim in perims:
+    for search_perimeter in SEARCH_PERIMETERS:
         # Departure
         new_departure_coords = find_nearest(
             departure_coords[0],
             departure_coords[1],
-            perim,
+            search_perimeter,
         )
         if new_departure_coords != False:
             # Then we found a better place, we can stop the loop
             break
+
     # Maybe here try to check if the API is not already working
     if new_departure_coords == False:
         # Then we will find nothing
         gdf = pd.DataFrame()
         success = False
         train_dist = None
-    # return None, False
+
     else:
         # We can retry the API
         gdf, success, train_dist = find_train(new_departure_coords, arrival_coords)
         if success == False:
             # We can change arrival_coords
-            for perim in perims:  # Could be up to 10k  ~ size of Bdx
-                # Arrival
+            for search_perimeter in SEARCH_PERIMETERS:
+                # Could be up to 10k  ~ size of Bdx
                 new_arrival_coords = find_nearest(
                     arrival_coords[0],
                     arrival_coords[1],
-                    perim,
+                    search_perimeter,
                 )
                 if new_arrival_coords != False:
                     break
@@ -213,7 +213,6 @@ def train_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    perims=search_perimeter,
     validate=val_perimeter,
 ):
     """Find the train path between 2 points and compute the emissions of the path.
@@ -221,7 +220,6 @@ def train_to_gdf(
     Parameters
     ----------
         - departure_coords, arrival_coords
-        - perims
         - validate
 
     Returns
@@ -243,7 +241,6 @@ def train_to_gdf(
         geometry, success, train_dist = extend_search(
             departure_coords,
             arrival_coords,
-            perims,
         )
 
     # Validation part for train

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -37,7 +37,7 @@ from parameters import val_perimeter
 from utils import (
     kilometer_to_degree,
     split_path_by_country,
-    validate_geom,
+    validate_geometry,
 )
 
 
@@ -244,7 +244,7 @@ def train_to_gdf(
         )
 
     # Validation part for train
-    if not success or not validate_geom(
+    if not success or not validate_geometry(
         departure_coords,
         arrival_coords,
         gpd.GeoSeries(

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -35,8 +35,6 @@ from models import (
 )
 from parameters import (
     search_perimeter,
-    train_s,
-    train_t,
     val_perimeter,
 )
 from utils import (
@@ -182,17 +180,13 @@ def find_train(
     """
     # Build the request url
     if method == "trainmap":
-        url = (
-            f"https://trainmap.ntag.fr/api/route?dep={departure_coords[0]},{departure_coords[1]}&arr={arrival_coords[0]},{arrival_coords[1]}&simplify="
-            + train_t
-        )  # 1 to simplify it
+        url = f"https://trainmap.ntag.fr/api/route?dep={departure_coords[0]},{departure_coords[1]}&arr={arrival_coords[0]},{arrival_coords[1]}&simplify=1"
 
     else:
         url = (
-            f"https://signal.eu.org/osm/eu/route/v1/train/{departure_coords[0]},{departure_coords[1]};{arrival_coords[0]},{arrival_coords[1]}?overview="
-            + train_s
-            + "&geometries=geojson"
-        )  # simplified
+            f"https://signal.eu.org/osm/eu/route/v1/train/{departure_coords[0]},{departure_coords[1]};{arrival_coords[0]},{arrival_coords[1]}"
+            "?overview=simplified&geometries=geojson"
+        )
 
     # Send the GET request
     response = requests.get(url)

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -33,7 +33,6 @@ from models import (
     TripStepResult,
     TripType,
 )
-from parameters import val_perimeter
 from utils import (
     kilometer_to_degree,
     split_path_by_country,
@@ -213,14 +212,12 @@ def train_to_gdf(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     trip_type: TripType,
-    validate=val_perimeter,
 ):
     """Find the train path between 2 points and compute the emissions of the path.
 
     Parameters
     ----------
         - departure_coords, arrival_coords
-        - validate
 
     Returns
     -------
@@ -251,7 +248,6 @@ def train_to_gdf(
             geometry,
             crs="epsg:4326",
         ).values[0],
-        validate,
     ):
         return None
 

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -34,7 +34,6 @@ from models import (
     TripType,
 )
 from parameters import (
-    EF_train,
     search_perimeter,
     train_s,
     train_t,
@@ -45,6 +44,13 @@ from utils import (
     split_path_by_country,
     validate_geom,
 )
+
+
+# Train emissions factors (kgCO2e / passenger.km).
+# Sources: SNCF "INFORMATION SUR LA QUANTITE DE GAZ A EFFET DE SERRE EMISE A l'OCCASION D'UNE
+# PRESTATION DE TRANSPORT" (2024)
+# https://medias.sncf.com/sncfcom/rse/methodologie-generale-infoges.pdf
+EF_TRAIN_INFRA = 0.0065
 
 
 class GeometryRecognitionError(Exception):
@@ -214,7 +220,6 @@ def train_to_gdf(
     arrival_coords: tuple[float, float],
     trip_type: TripType,
     perims=search_perimeter,
-    EF_train=EF_train,
     validate=val_perimeter,
 ):
     """Find the train path between 2 points and compute the emissions of the path.
@@ -273,8 +278,8 @@ def train_to_gdf(
     # Add infra emissions
     gdf = pd.concat([
         pd.DataFrame({
-            "kgCO2eq": [train_dist * EF_train["infra"]],
-            "EF": [EF_train["infra"]],
+            "kgCO2eq": [train_dist * EF_TRAIN_INFRA],
+            "EF": [EF_TRAIN_INFRA],
             "NAME": ["infra"],
             "path_length": [train_dist],
         }),
@@ -333,7 +338,7 @@ def train_to_gdf(
             transport="train",
             emissions=emissions,
             path_length=round(train_dist),
-            coeff_upstream=EF_train["infra"],
+            coeff_upstream=EF_TRAIN_INFRA,
         ),
         geometries=geometries,
     )

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -161,7 +161,7 @@ def validate_geometry(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
     geometry: BaseGeometry | None,
-    distance_threshold,
+    distance_threshold=100,
 ):
     """Validate that the route geometry matches the requested coordinates by checking
     that the departure and arrival of geometries are close enough to the ones requested.

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -32,7 +32,6 @@ from shapely.geometry.base import BaseGeometry
 from models import TripPayload, TripStep
 from parameters import (
     carbon_intensity_electricity,
-    sea_threshold as default_sea_threshold,
     train_intensity,
 )
 
@@ -47,7 +46,7 @@ def split_path_by_country(
     path: LineString,
     method: str,
     real_path_length: float,
-    sea_threshold=default_sea_threshold,
+    sea_threshold=5,
 ):
     """Split the path by country and compute the length of each of its parts.
 
@@ -55,7 +54,7 @@ def split_path_by_country(
     ----------
         - path : path geometry in LineString
         - mode : train / ecar
-        - th : threshold to remove unmatched gaps between countries that are too small (km)
+        - sea_threshold : threshold to remove unmatched gaps between countries that are too small (km)
     return:
         - geodataframe of path parts by countries
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -27,6 +27,7 @@ from pyproj import Geod
 # Web
 from shapely import ops
 from shapely.geometry import LineString, MultiLineString
+from shapely.geometry.base import BaseGeometry
 
 from models import TripPayload, TripStep
 from parameters import (
@@ -156,31 +157,41 @@ def split_path_by_country(
     return gdf.drop(iso, axis=1)
 
 
-def validate_geom(tag1, tag2, geom, th):
-    """Verify that the departure and arrival of geometries are close enough to the ones requested
-    parameters:
-        - tag1, tag2 : requested coordinates
-        - geom : shapely geometry answered
-        - th : threshold (km) for which we reject the geometry
-    return:
-        boolean (True valid geometry / False wrong geometry).
+def validate_geometry(
+    departure_coords: tuple[float, float],
+    arrival_coords: tuple[float, float],
+    geometry: BaseGeometry | None,
+    distance_threshold,
+):
+    """Validate that the route geometry matches the requested coordinates by checking
+    that the departure and arrival of geometries are close enough to the ones requested.
+
+    Args:
+        departure_coords: Requested departure coordinates.
+        arrival_coords: Requested arrival coordinates.
+        geometry: Route geometry to validate.
+        distance_threshold: Maximum allowed distance in kilometers.
+
+    Returns:
+        ``True`` if the geometry is valid, otherwise ``False``.
+
     """
     geod = Geod(ellps="WGS84")
 
     # To compute distances
     # Creating geometries for departure
-    ecart = LineString([tag1, list(geom.coords)[0]])
+    ecart = LineString([departure_coords, list(geometry.coords)[0]])
 
     # Maybe geod can compute length between 2 points directly
-    if geod.geometry_length(ecart) / 1e3 > th:
+    if geod.geometry_length(ecart) / 1e3 > distance_threshold:
         print("Departure is not valid")
         return False
 
     # Arrival
-    ecart = LineString([tag2, list(geom.coords)[-1]])
+    ecart = LineString([arrival_coords, list(geometry.coords)[-1]])
 
     # Maybe geod can compute length between 2 points directly
-    if geod.geometry_length(ecart) / 1e3 > th:
+    if geod.geometry_length(ecart) / 1e3 > distance_threshold:
         print("Arrival is not valid")
         return False
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -65,13 +65,19 @@ def split_path_by_country(
     )
 
     if method == "train":
+        # Sources:
+        # - European countries: ADEME Base Carbone (2024)
+        # - China, Japan, USA, India & Russia: Railway Handbook produced by the International
+        #   and Environmental Agency and the Union of Railways (2017, https://uic.org/IMG/pdf/handbook_iea-uic_2017_web3.pdf)
+        # - other countries: 100gCO2 /p.km by default
+        data = train_intensity
         iso = "ISO2"
         EF = "EF_tot"
-        data = train_intensity
     else:  # ecar
+        # Source: Our World in Data (2024) - https://ourworldindata.org/electricity-mix
+        data = carbon_intensity_electricity
         iso = "Code"
         EF = "mix"
-        data = carbon_intensity_electricity
 
     # Split by geometry
     gdf.name = "geometry"


### PR DESCRIPTION
Emissions factors were never customized. To improve readability, use the internal constants directly.

Also added some documentation in the code, to explain the source of the constants.