### PR TITLE
🔧 back: isolate GeoPandas logic in split_path_by_country

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -18,6 +18,7 @@
 from dataclasses import dataclass
 from typing import Literal
 
+import geopandas as gpd
 from shapely.geometry.base import BaseGeometry
 
 
@@ -46,6 +47,17 @@ class TripStep:
     transport_means: str
     passengers_nb: str | None
     options: str | None
+
+
+@dataclass(frozen=True)
+class CountrySplitConfig:
+    """Configuration for the function split_path_by_country (depends on the
+    means of transport).
+    """
+
+    dataset: gpd.GeoDataFrame
+    iso_column: str
+    emission_factor_column: str
 
 
 @dataclass(frozen=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -18,6 +18,8 @@
 from dataclasses import dataclass
 from typing import Literal
 
+from shapely.geometry.base import BaseGeometry
+
 
 ######################
 # INPUTS
@@ -44,6 +46,16 @@ class TripStep:
     transport_means: str
     passengers_nb: str | None
     options: str | None
+
+
+@dataclass(frozen=True)
+class CountryRouteSegment:
+    """Segment of route in a specific country."""
+
+    country_name: str
+    emission_factor: float
+    geometry: BaseGeometry
+    path_length_km: float
 
 
 ######################

--- a/backend/parameters.py
+++ b/backend/parameters.py
@@ -9,8 +9,14 @@ from pyproj import Geod
 GEOD = Geod(ellps="WGS84")
 
 
-# Load world datasets
+# Sources:
+# - European countries: ADEME Base Carbone (2024)
+# - China, Japan, USA, India & Russia: Railway Handbook produced by the International
+#   and Environmental Agency and the Union of Railways (2017, https://uic.org/IMG/pdf/handbook_iea-uic_2017_web3.pdf)
+# - other countries: 100gCO2 /p.km by default
 train_intensity = gpd.read_file("static/train_intensity.geojson")
+
+# Source: Our World in Data (2024) - https://ourworldindata.org/electricity-mix
 carbon_intensity_electricity = gpd.read_file(
     "static/carbon_intensity_electricity.geojson",
 )

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -24,12 +24,14 @@ from shapely.geometry import LineString
 from models import (
     BusStepData,
     CarStepData,
+    CountrySplitConfig,
     EcarStepData,
     EmissionPart,
     TripStepGeometry,
     TripStepResult,
     TripType,
 )
+from parameters import carbon_intensity_electricity
 from utils import (
     m_to_km,
     split_path_by_country,
@@ -54,6 +56,12 @@ EF_BUS_FUEL = 0.025
 EF_ECAR_CONSTRUCTION = 0.0836
 # Source: EV Database (2024) - https://ev-database.org/cheatsheet/energy-consumption-electric-car
 EF_ECAR_FUEL = 0.187
+
+ECAR_COUNTRY_SPLIT_CONFIG = CountrySplitConfig(
+    dataset=carbon_intensity_electricity,
+    iso_column="Code",
+    emission_factor_column="mix",
+)
 
 # Additional vehicle emissions generated per extra passenger.
 # Used to adjust transport emissions based on occupancy.
@@ -150,8 +158,8 @@ def compute_ecar_trip(
     # We need to filter by country and add length / Emission factors
     country_route_segments, geometries = split_path_by_country(
         route_geometry,
-        method="ecar",
-        real_path_length=route_length,
+        route_length,
+        ECAR_COUNTRY_SPLIT_CONFIG,
         trip_type=trip_type,
     )
 

--- a/backend/transport_car.py
+++ b/backend/transport_car.py
@@ -18,7 +18,6 @@
 from dataclasses import dataclass
 from http import HTTPStatus
 
-import pandas as pd
 import requests
 from shapely.geometry import LineString
 
@@ -121,10 +120,26 @@ def compute_ecar_trip(
     trip_type: TripType,
     passengers_nb=1,
 ):
-    """Parameters
-        - departure_coords, arrival_coords
-    return:
-        - full dataframe for trains.
+    """Compute an electric car trip between two coordinates.
+
+    Finds a road route, validates its geometry, and computes the associated
+    transport emissions and trip metadata.
+
+    The route is split by country to apply country-specific electricity
+    emission factors based on the distance traveled in each country.
+
+    Emissions are adjusted according to the number of passengers by adding
+    4% additional emissions per extra passenger.
+
+    Args:
+        departure_coords: Departure coordinates as (longitude, latitude).
+        arrival_coords: Arrival coordinates as (longitude, latitude).
+        trip_type: Type of trip to compute.
+        passengers_nb: Number of passengers in the vehicle.
+
+    Returns:
+        A ``TripStepResult`` containing the route geometry and emissions
+        data, or ``None`` if no valid route could be found.
 
     """
     route_geometry, route_length, success = find_route(departure_coords, arrival_coords)
@@ -133,62 +148,39 @@ def compute_ecar_trip(
         return None
 
     # We need to filter by country and add length / Emission factors
-    gdf = split_path_by_country(
+    country_route_segments, geometries = split_path_by_country(
         route_geometry,
         method="ecar",
         real_path_length=route_length,
+        trip_type=trip_type,
     )
 
     passengers_nb = int(passengers_nb)
     passenger_adjustment_factor = compute_passenger_adjustment_factor(passengers_nb)
-    gdf["EF"] /= 1000.0  # Conversion in kg
-
-    gdf["EF_tot"] = gdf["EF"] * EF_ECAR_FUEL * passenger_adjustment_factor
-    gdf["kgCO2eq"] = gdf["path_length"] * gdf["EF_tot"]
-
-    # Add infra and construction
-    gdf = pd.concat([
-        pd.DataFrame({
-            "kgCO2eq": [route_length * EF_ECAR_CONSTRUCTION / passengers_nb],
-            "EF": [EF_ECAR_CONSTRUCTION],
-            "NAME": ["construction"],
-            "path_length": [route_length],
-        }),
-        gdf,
-    ])
-    gdf["label"] = "Road"
-    gdf["length"] = str(int(route_length)) + "km (" + gdf["NAME"] + ")"
-    gdf.reset_index(inplace=True)
-
-    geo_ecar = gdf[["label", "geometry", "path_length", "NAME"]].dropna(
-        axis=0,
-    )
-
-    geometries = []
-    for _, row in geo_ecar.iterrows():
-        geometries.append(
-            TripStepGeometry(
-                coordinates=[[list(coord) for coord in row["geometry"].coords]],
-                transport_means="Road",
-                length=row["path_length"],
-                country_label=row["NAME"],
-                trip_type=trip_type,
-            ),
-        )
-
-    emissions_data = gdf[["kgCO2eq", "NAME", "EF", "path_length"]].to_dict(
-        "records",
-    )
 
     emissions = [
         EmissionPart(
-            name=emission_data["NAME"],
-            kg_co2_eq=round(emission_data["kgCO2eq"], 2),
-            ef_tot=emission_data["EF"],
-            distance=round(emission_data["path_length"]),
+            name=segment.country_name,
+            kg_co2_eq=round(
+                segment.emission_factor
+                * EF_ECAR_FUEL
+                * passenger_adjustment_factor
+                * segment.path_length_km,
+                2,
+            ),
+            ef_tot=segment.emission_factor,
+            distance=round(segment.path_length_km),
         )
-        for emission_data in emissions_data
+        for segment in country_route_segments
     ]
+    emissions.append(
+        EmissionPart(
+            name="construction",
+            kg_co2_eq=round(route_length * EF_ECAR_CONSTRUCTION / passengers_nb),
+            ef_tot=EF_ECAR_CONSTRUCTION,
+            distance=round(route_length),
+        ),
+    )
 
     return TripStepResult(
         step_data=EcarStepData(

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -22,14 +22,12 @@ import pandas as pd
 import requests
 from shapely.geometry import (
     LineString,
-    MultiLineString,
     Point,
 )
 
 from models import (
     EmissionPart,
     TrainStepData,
-    TripStepGeometry,
     TripStepResult,
     TripType,
 )
@@ -226,7 +224,6 @@ def compute_train_trip(
 
     Raises
     ------
-    GeometryRecognitionError
         If the geometry is not recognized.
 
     """
@@ -252,74 +249,31 @@ def compute_train_trip(
     ):
         return None
 
-    # Split path by country and compute for each part of the path, the length and the emission factor
-    gdf = split_path_by_country(
+    # Split path by country and compute the length and the emission factor for each part of the path
+    country_route_segments, geometries = split_path_by_country(
         geometry,
         method="train",
         real_path_length=train_dist,
+        trip_type=trip_type,
     )
 
-    # Compute emissions : EF * length
-    gdf["EF"] /= 1000.0  # Conversion in kg
-    gdf["kgCO2eq"] = gdf["path_length"] * gdf["EF"]
-
-    # Add infra emissions
-    gdf = pd.concat([
-        pd.DataFrame({
-            "kgCO2eq": [train_dist * EF_TRAIN_INFRA],
-            "EF": [EF_TRAIN_INFRA],
-            "NAME": ["infra"],
-            "path_length": [train_dist],
-        }),
-        gdf,
-    ])
-
-    gdf.reset_index(inplace=True)
-
-    geo_train = (
-        gdf[["geometry", "path_length", "NAME"]].dropna(axis=0).to_dict("records")
-    )
-
-    geometries = []
-    for geo in geo_train:
-        if type(geo["geometry"]) is LineString:
-            geometries.append(
-                TripStepGeometry(
-                    coordinates=[[list(coord) for coord in geo["geometry"].coords]],
-                    transport_means="Railway",
-                    length=geo["path_length"],
-                    country_label=geo["NAME"],
-                    trip_type=trip_type,
-                ),
-            )
-        elif type(geo["geometry"]) is MultiLineString:
-            coordinates = []
-            for l in geo["geometry"].geoms:
-                coordinates.append([list(coord) for coord in l.coords])
-            geometries.append(
-                TripStepGeometry(
-                    coordinates=coordinates,
-                    transport_means="Railway",
-                    length=geo["path_length"],
-                    country_label=geo["NAME"],
-                    trip_type=trip_type,
-                ),
-            )
-        else:
-            raise GeometryRecognitionError
-
-    emissions_data = gdf[["kgCO2eq", "NAME", "EF", "path_length"]].to_dict(
-        "records",
-    )
     emissions = [
         EmissionPart(
-            name=emission_data["NAME"],
-            kg_co2_eq=round(emission_data["kgCO2eq"], 2),
-            ef_tot=emission_data["EF"],
-            distance=round(emission_data["path_length"]),
+            name=segment.country_name,
+            kg_co2_eq=round(segment.emission_factor * segment.path_length_km, 2),
+            ef_tot=segment.emission_factor,
+            distance=round(segment.path_length_km),
         )
-        for emission_data in emissions_data
+        for segment in country_route_segments
     ]
+    emissions.append(
+        EmissionPart(
+            name="infra",
+            kg_co2_eq=round(train_dist * EF_TRAIN_INFRA),
+            ef_tot=EF_TRAIN_INFRA,
+            distance=round(train_dist),
+        ),
+    )
 
     return TripStepResult(
         step_data=TrainStepData(

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -26,11 +26,13 @@ from shapely.geometry import (
 )
 
 from models import (
+    CountrySplitConfig,
     EmissionPart,
     TrainStepData,
     TripStepResult,
     TripType,
 )
+from parameters import train_intensity
 from utils import (
     kilometer_to_degree,
     m_to_km,
@@ -44,6 +46,13 @@ from utils import (
 # PRESTATION DE TRANSPORT" (2024)
 # https://medias.sncf.com/sncfcom/rse/methodologie-generale-infoges.pdf
 EF_TRAIN_INFRA = 0.0065
+
+
+TRAIN_COUNTRY_SPLIT_CONFIG = CountrySplitConfig(
+    dataset=train_intensity,
+    iso_column="ISO2",
+    emission_factor_column="EF_tot",
+)
 
 
 class GeometryRecognitionError(Exception):
@@ -252,8 +261,8 @@ def compute_train_trip(
     # Split path by country and compute the length and the emission factor for each part of the path
     country_route_segments, geometries = split_path_by_country(
         geometry,
-        method="train",
-        real_path_length=train_dist,
+        train_dist,
+        TRAIN_COUNTRY_SPLIT_CONFIG,
         trip_type=trip_type,
     )
 

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -28,7 +28,13 @@ from shapely import ops
 from shapely.geometry import LineString, MultiLineString
 from shapely.geometry.base import BaseGeometry
 
-from models import TripPayload, TripStep
+from models import (
+    CountryRouteSegment,
+    TripPayload,
+    TripStep,
+    TripStepGeometry,
+    TripType,
+)
 from parameters import (
     carbon_intensity_electricity,
     GEOD,
@@ -53,21 +59,47 @@ def compute_distance_between_2_points(
     return m_to_km(GEOD.geometry_length(LineString([point1, point2])))
 
 
+class GeometryRecognitionError(Exception):
+    """Exception raised when the geometry is not recognized."""
+
+
 def split_path_by_country(
     path: LineString,
     method: str,
     real_path_length: float,
+    trip_type: TripType,
     sea_threshold=5,
-):
-    """Split the path by country and compute the length of each of its parts.
+) -> tuple[list[CountryRouteSegment], list[TripStepGeometry]]:
+    """Split a route by country and compute country-specific route segments.
 
-    Parameters
-    ----------
-        - path : path geometry in LineString
-        - mode : train / ecar
-        - sea_threshold : threshold to remove unmatched gaps between countries that are too small (km)
-    return:
-        - geodataframe of path parts by countries
+    The route geometry is intersected with country boundaries to determine
+    the distance traveled in each country. Country-specific emission
+    factors are then attached to each segment depending on the transport
+    method.
+
+    Unmatched route parts (typically sea crossings, bridges, or tunnels)
+    can optionally be reassigned to the nearest country when their length
+    exceeds the sea_threshold.
+
+    Args:
+        path: Route geometry as a LineString.
+        method: Transport method used to select the emission factor dataset
+            (e.g. "train" or "ecar").
+        real_path_length: Total route length in kilometers used to rescale
+            computed geometry lengths.
+        trip_type: Type of trip associated with the generated geometries.
+        sea_threshold: Minimum unmatched segment length in kilometers before
+            reassignment to the nearest country.
+
+    Returns:
+        A tuple containing:
+            - A list of CountryRouteSegment with country-specific
+            emission factors and traveled distances.
+            - A list of TripStepGeometry for frontend trip rendering.
+
+    Raises:
+        GeometryRecognitionError:
+            If a route geometry cannot be converted to trip coordinates.
 
     """
     gdf = gpd.GeoSeries(
@@ -154,17 +186,62 @@ def split_path_by_country(
 
     gdf = gpd.GeoDataFrame(u, geometry="geometry", crs="epsg:4326").reset_index()
 
-    # Compute the length of each part of the path
-    l_length = []
-    for geom in gdf.geometry.values:
-        part_length = m_to_km(GEOD.geometry_length(geom))
-        l_length.append(part_length)
-    gdf["path_length"] = l_length
+    raw_segments = [
+        CountryRouteSegment(
+            country_name=row["NAME"],
+            emission_factor=row["EF"] / 1000,  # conversion in kg
+            geometry=row["geometry"],
+            path_length_km=m_to_km(GEOD.geometry_length(row["geometry"])),
+        )
+        for _, row in gdf.iterrows()
+    ]
 
-    # Rescale the length with train_dist (especially when simplified = True)
-    gdf["path_length"] *= real_path_length / gdf["path_length"].sum()
+    total_length = sum(segment.path_length_km for segment in raw_segments)
+    scale_factor = real_path_length / total_length
 
-    return gdf.drop(iso, axis=1)
+    segments = []
+    geometries = []
+
+    for segment in raw_segments:
+        # rescale segment_length with real_path_length
+        segment_length = segment.path_length_km * scale_factor
+
+        # compute country route segment
+        segments.append(
+            CountryRouteSegment(
+                country_name=segment.country_name,
+                emission_factor=segment.emission_factor,
+                geometry=segment.geometry,
+                path_length_km=segment_length,
+            ),
+        )
+
+        # compute trip step geometry
+        if isinstance(segment.geometry, LineString):
+            coordinates = [
+                [list(coord) for coord in segment.geometry.coords],
+            ]
+
+        elif isinstance(segment.geometry, MultiLineString):
+            coordinates = [
+                [list(coord) for coord in line.coords]
+                for line in segment.geometry.geoms
+            ]
+
+        else:
+            raise GeometryRecognitionError
+
+        geometries.append(
+            TripStepGeometry(
+                coordinates=coordinates,
+                transport_means="Railway",
+                length=segment_length,
+                country_label=segment.country_name,
+                trip_type=trip_type,
+            ),
+        )
+
+    return segments, geometries
 
 
 def validate_geometry(

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -60,6 +60,21 @@ class GeometryRecognitionError(Exception):
     """Exception raised when the geometry is not recognized."""
 
 
+def get_coordinates_from_base_geometry(geometry: BaseGeometry):
+    """Convert a Shapely geometry into nested coordinate lists.
+
+    Raises:
+        GeometryRecognitionError:
+            If a route geometry cannot be converted to trip coordinates.
+
+    """
+    if isinstance(geometry, LineString):
+        return [[list(coord) for coord in geometry.coords]]
+    if isinstance(geometry, MultiLineString):
+        return [[list(coord) for coord in line.coords] for line in geometry.geoms]
+    raise GeometryRecognitionError
+
+
 def split_path_by_country(
     path: LineString,
     real_path_length: float,
@@ -92,10 +107,6 @@ def split_path_by_country(
             - A list of CountryRouteSegment with country-specific
             emission factors and traveled distances.
             - A list of TripStepGeometry for frontend trip rendering.
-
-    Raises:
-        GeometryRecognitionError:
-            If a route geometry cannot be converted to trip coordinates.
 
     """
     gdf = gpd.GeoSeries(
@@ -190,20 +201,9 @@ def split_path_by_country(
         )
 
         # compute trip step geometry
-        if isinstance(segment.geometry, LineString):
-            coordinates = [
-                [list(coord) for coord in segment.geometry.coords],
-            ]
-
-        elif isinstance(segment.geometry, MultiLineString):
-            coordinates = [
-                [list(coord) for coord in line.coords]
-                for line in segment.geometry.geoms
-            ]
-
-        else:
-            raise GeometryRecognitionError
-
+        coordinates = get_coordinates_from_base_geometry(
+            segment.geometry,
+        )
         geometries.append(
             TripStepGeometry(
                 coordinates=coordinates,

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -30,16 +30,13 @@ from shapely.geometry.base import BaseGeometry
 
 from models import (
     CountryRouteSegment,
+    CountrySplitConfig,
     TripPayload,
     TripStep,
     TripStepGeometry,
     TripType,
 )
-from parameters import (
-    carbon_intensity_electricity,
-    GEOD,
-    train_intensity,
-)
+from parameters import GEOD
 
 
 # Not really accurate but good enough and fast for some purposes
@@ -65,8 +62,8 @@ class GeometryRecognitionError(Exception):
 
 def split_path_by_country(
     path: LineString,
-    method: str,
     real_path_length: float,
+    country_split_config: CountrySplitConfig,
     trip_type: TripType,
     sea_threshold=5,
 ) -> tuple[list[CountryRouteSegment], list[TripStepGeometry]]:
@@ -83,10 +80,9 @@ def split_path_by_country(
 
     Args:
         path: Route geometry as a LineString.
-        method: Transport method used to select the emission factor dataset
-            (e.g. "train" or "ecar").
         real_path_length: Total route length in kilometers used to rescale
             computed geometry lengths.
+        country_split_config: Configuration depending on the means of transport.
         trip_type: Type of trip associated with the generated geometries.
         sea_threshold: Minimum unmatched segment length in kilometers before
             reassignment to the nearest country.
@@ -107,31 +103,16 @@ def split_path_by_country(
         crs="epsg:4326",
     )
 
-    if method == "train":
-        # Sources:
-        # - European countries: ADEME Base Carbone (2024)
-        # - China, Japan, USA, India & Russia: Railway Handbook produced by the International
-        #   and Environmental Agency and the Union of Railways (2017, https://uic.org/IMG/pdf/handbook_iea-uic_2017_web3.pdf)
-        # - other countries: 100gCO2 /p.km by default
-        data = train_intensity
-        iso = "ISO2"
-        EF = "EF_tot"
-    else:  # ecar
-        # Source: Our World in Data (2024) - https://ourworldindata.org/electricity-mix
-        data = carbon_intensity_electricity
-        iso = "Code"
-        EF = "mix"
-
     # Split by geometry
     gdf.name = "geometry"
     res = gpd.overlay(
         gpd.GeoDataFrame(gdf, geometry="geometry", crs="epsg:4326"),
-        data,
+        country_split_config.dataset,
         how="intersection",
     )
     diff = gpd.overlay(
         gpd.GeoDataFrame(gdf, geometry="geometry", crs="epsg:4326"),
-        data,
+        country_split_config.dataset,
         how="difference",
     )
 
@@ -150,7 +131,7 @@ def split_path_by_country(
 
         # Filter depending is the gap is long enough to be taken into account and join with nearest country
         test = diff_2[diff_2.length > kilometer_to_degree(sea_threshold)].sjoin_nearest(
-            data,
+            country_split_config.dataset,
             how="left",
         )
 
@@ -158,10 +139,10 @@ def split_path_by_country(
         u = (
             pd
             .concat([res.explode(), test.explode()])
-            .groupby(iso)
+            .groupby(country_split_config.iso_column)
             .agg(
                 NAME=("NAME", lambda x: x.iloc[0]),
-                EF=(EF, lambda x: x.iloc[0]),
+                EF=(country_split_config.emission_factor_column, lambda x: x.iloc[0]),
                 geometry=(
                     "geometry",
                     lambda x: ops.linemerge(MultiLineString(x.values)),
@@ -173,10 +154,10 @@ def split_path_by_country(
         u = (
             res
             .explode()
-            .groupby(iso)
+            .groupby(country_split_config.iso_column)
             .agg(
                 NAME=("NAME", lambda x: x.iloc[0]),
-                EF=(EF, lambda x: x.iloc[0]),
+                EF=(country_split_config.emission_factor_column, lambda x: x.iloc[0]),
                 geometry=(
                     "geometry",
                     lambda x: ops.linemerge(MultiLineString(x.values)),

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -105,67 +105,59 @@ def split_path_by_country(
 
     # Split by geometry
     gdf.name = "geometry"
-    res = gpd.overlay(
+    intersections = gpd.overlay(
         gpd.GeoDataFrame(gdf, geometry="geometry", crs="epsg:4326"),
         country_split_config.dataset,
         how="intersection",
     )
-    diff = gpd.overlay(
+    unmatched_segments = gpd.overlay(
         gpd.GeoDataFrame(gdf, geometry="geometry", crs="epsg:4326"),
         country_split_config.dataset,
         how="difference",
     )
 
     # Check if the unmatched data is significant
-    if diff.length.sum() > kilometer_to_degree(sea_threshold):
-        print("Sea detected")
-        # In case we have bridges / tunnels across sea:
-        # Distinction depending on linestring / multilinestring
-        if diff.geometry[0].geom_type == "MultiLineString":
-            diff_2 = gpd.GeoDataFrame(list(diff.geometry.values[0].geoms))
-        else:
-            diff_2 = gpd.GeoDataFrame(list(diff.geometry.values))
+    if unmatched_segments.length.sum() < kilometer_to_degree(sea_threshold):
+        segments_to_aggregate = intersections.explode()
 
-        diff_2.columns = ["geometry"]
-        diff_2 = diff_2.set_geometry("geometry", crs="epsg:4326")
+    else:
+        print("Sea detected")
+
+        # In case we have bridges / tunnels across sea:
+        if unmatched_segments.geometry.iloc[0].geom_type == "MultiLineString":
+            sea_segments = gpd.GeoDataFrame(
+                list(unmatched_segments.geometry.iloc[0].geoms),
+            )
+        else:
+            sea_segments = gpd.GeoDataFrame(list(unmatched_segments.geometry.values))
+
+        sea_segments.columns = ["geometry"]
+        sea_segments = sea_segments.set_geometry("geometry", crs="epsg:4326")
 
         # Filter depending is the gap is long enough to be taken into account and join with nearest country
-        test = diff_2[diff_2.length > kilometer_to_degree(sea_threshold)].sjoin_nearest(
+        nearest_country_segments = sea_segments[
+            sea_segments.length > kilometer_to_degree(sea_threshold)
+        ].sjoin_nearest(
             country_split_config.dataset,
             how="left",
         )
 
-        # Aggregation per country and combining geometries
-        u = (
-            pd
-            .concat([res.explode(), test.explode()])
-            .groupby(country_split_config.iso_column)
-            .agg(
-                NAME=("NAME", lambda x: x.iloc[0]),
-                EF=(country_split_config.emission_factor_column, lambda x: x.iloc[0]),
-                geometry=(
-                    "geometry",
-                    lambda x: ops.linemerge(MultiLineString(x.values)),
-                ),
-            )
-        )
+        segments_to_aggregate = pd.concat([
+            intersections.explode(),
+            nearest_country_segments.explode(),
+        ])
 
-    else:
-        u = (
-            res
-            .explode()
-            .groupby(country_split_config.iso_column)
-            .agg(
-                NAME=("NAME", lambda x: x.iloc[0]),
-                EF=(country_split_config.emission_factor_column, lambda x: x.iloc[0]),
-                geometry=(
-                    "geometry",
-                    lambda x: ops.linemerge(MultiLineString(x.values)),
-                ),
-            )
-        )
-
-    gdf = gpd.GeoDataFrame(u, geometry="geometry", crs="epsg:4326").reset_index()
+    # Aggregation per country and combining geometries
+    aggregated_segments = segments_to_aggregate.groupby(
+        country_split_config.iso_column,
+    ).agg(
+        NAME=("NAME", "first"),
+        EF=(country_split_config.emission_factor_column, "first"),
+        geometry=(
+            "geometry",
+            lambda x: ops.linemerge(MultiLineString(x.values)),
+        ),
+    )
 
     raw_segments = [
         CountryRouteSegment(
@@ -174,7 +166,7 @@ def split_path_by_country(
             geometry=row["geometry"],
             path_length_km=m_to_km(GEOD.geometry_length(row["geometry"])),
         )
-        for _, row in gdf.iterrows()
+        for _, row in aggregated_segments.iterrows()
     ]
 
     total_length = sum(segment.path_length_km for segment in raw_segments)


### PR DESCRIPTION
Limit GeoPandas usage to GIS processing and return typed domain objects instead of GeoDataFrames to improve readability and separate spatial processing from core logic.