### PR TITLE
📦 back: bump numpy, pandas, shapely and pyproj

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,11 +1,13 @@
-flask == 2.2.2
-shapely == 2.0.1
+# maths / geo
+numpy == 1.26.4
+pandas == 2.2.0
 geopandas == 0.14.4
-pandas == 2.0.0
-numpy == 1.23.2
+shapely == 2.1.2
+pyproj == 3.7.2
+
+flask == 2.2.2
 networkx == 2.8.4
 momepy == 0.6.0
-pyproj == 3.6.1
 requests == 2.28.1
 Werkzeug == 2.2.2
 gunicorn


### PR DESCRIPTION
numpy is not compatible with python 3.12, but all the other libs are not compatible with numpy 1.26.4. So they need to be bumped together.

Will close https://github.com/XavB64/lowtrip/pull/223 and https://github.com/XavB64/lowtrip/pull/217