### PR TITLE
back: bump flask and werkzeug

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -5,11 +5,13 @@ geopandas == 0.14.4
 shapely == 2.1.2
 pyproj == 3.7.2
 
-flask == 2.2.2
+# framework
+flask == 3.1.3
+Werkzeug == 3.1.8
+
 networkx == 2.8.4
 momepy == 0.6.0
 requests == 2.34.2
-Werkzeug == 2.2.2
 gunicorn
 flask_cors
 pyogrio


### PR DESCRIPTION
Werkzeug must be considered as an internal dependence of flask. They need to be upgraded together.

Will close https://github.com/XavB64/lowtrip/pull/337 (bump flask)
Will close https://github.com/XavB64/lowtrip/pull/389 (bump werkzeug)