### PR TITLE
⭐ front: focus inputs by default

### DIFF
--- a/frontend/src/MainView/Form/CityDropdown.tsx
+++ b/frontend/src/MainView/Form/CityDropdown.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from "react";
+import { useState, useEffect, useMemo, useRef } from "react";
 
 import i18n from "i18next";
 import { useTranslation } from "react-i18next";
@@ -68,7 +68,11 @@ const CityDropdown = ({
   stepIndex,
 }: CityDropdownProps) => {
   const { t } = useTranslation();
+
   const { getCacheValue, addToCache, resetCache } = useCache();
+
+  const inputRef = useRef<HTMLInputElement | null>(null);
+
   const [results, setResults] = useState<City[]>([]);
   const [value, setValue] = useState("");
   const [isOpen, setIsOpen] = useState(false);
@@ -178,6 +182,8 @@ const CityDropdown = ({
   return (
     <div className="city-dropdown">
       <input
+        id={`dropdownId-${stepIndex}`}
+        ref={inputRef}
         type="text"
         className="city-dropdown-input"
         value={value}
@@ -187,7 +193,6 @@ const CityDropdown = ({
         placeholder={
           isDeparture ? t("form.placeholderFrom") : t("form.placeholderTo")
         }
-        id={`dropdownId-${stepIndex}`}
       />
 
       {isOpen && (
@@ -220,7 +225,10 @@ const CityDropdown = ({
           className="clear-input-button"
           aria-label="Clear input"
           title={t("form.clearInput")}
-          onClick={resetCity}
+          onClick={() => {
+            resetCity();
+            inputRef.current?.focus();
+          }}
         >
           ×
         </button>

--- a/frontend/src/MainView/Form/Form.tsx
+++ b/frontend/src/MainView/Form/Form.tsx
@@ -15,7 +15,7 @@
 // You should have received a copy of the GNU Affero General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-import { useMemo } from "react";
+import { useEffect, useMemo } from "react";
 
 import { useTranslation } from "react-i18next";
 import { BiSolidPlusCircle } from "react-icons/bi";
@@ -69,6 +69,11 @@ const Form = ({ displayedTrip, showAlternativeForm }: FormProps) => {
         : getAdviceTextTranslation(t, steps),
     [t, displayedTrip, mainSteps, alternativeSteps],
   );
+
+  useEffect(() => {
+    if (!steps.at(0)?.locationCoords)
+      document.getElementById("dropdownId-1")?.focus();
+  }, [displayedTrip]);
 
   return (
     <div

--- a/frontend/src/MainView/helpers/simulationContext/simulationContext.tsx
+++ b/frontend/src/MainView/helpers/simulationContext/simulationContext.tsx
@@ -56,14 +56,22 @@ export const SimulationProvider = ({ children }: { children: ReactNode }) => {
 
   const addStep = useCallback(
     (trip: TRIP_TYPE) => {
+      let newSteps: Step[];
+
       if (trip === TRIP_TYPE.MAIN) {
-        setSteps([...steps, { index: steps.length + 1, id: nextId() }]);
+        newSteps = [...steps, { index: steps.length + 1, id: nextId() }];
+        setSteps(newSteps);
       } else {
-        setAlternativeSteps([
+        newSteps = [
           ...alternativeSteps,
           { index: alternativeSteps.length + 1, id: nextId() },
-        ]);
+        ];
+        setAlternativeSteps(newSteps);
       }
+
+      requestAnimationFrame(() => {
+        document.getElementById(`dropdownId-${newSteps.length}`)?.focus();
+      });
     },
     [steps, alternativeSteps, setSteps, setAlternativeSteps],
   );


### PR DESCRIPTION
Focus city inputs:
- on the first render and when switching to the alternative form, focus on the first input if it is empty
- when adding a new step, automatically focus its input
- when clearing a step, automatically focus its input