### PR TITLE
🧹 front: fix React warning

### DIFF
--- a/frontend/src/MainView/Form/CityDropdown.tsx
+++ b/frontend/src/MainView/Form/CityDropdown.tsx
@@ -82,8 +82,11 @@ const CityDropdown = ({
   const query = useDebounce(value, 500);
   const isDeparture = stepIndex === 1;
 
-  const resultLng = useMemo(() => {
+  useEffect(() => {
     resetCache();
+  }, [i18n.language]);
+
+  const resultLng = useMemo(() => {
     switch (i18n.language) {
       case "en":
       case "fr":


### PR DESCRIPTION
When launching the application, we could see the following warning in the console: "Cannot update a component (CacheProvider) while rendering a different component (CityDropdown)."

This was due to resetCache which was executed during the first render of CityDropdown in the useMemo. Moving it to a useEffect solves the issue.