### PR TITLE
🐞 back: handle external routing service Signal outages gracefully

### DIFF
--- a/backend/models.py
+++ b/backend/models.py
@@ -114,6 +114,30 @@ class CountryRouteSegment:
     path_length_km: float
 
 
+ExternalApiErrorCode = Literal["timeout", "error", "http_error", "no_route"]
+
+ExternalService = Literal["signal", "overpass"]
+
+USAGES: dict[ExternalService, str] = {
+    "signal": "railway routing",
+    "overpass": "retrieving station coordinates",
+}
+
+
+class ExternalServiceDownError(Exception):
+    """Raised when an external service does not answer."""
+
+    def __init__(
+        self,
+        service: ExternalService,
+    ) -> None:
+        """Init ExternalServiceDown."""
+        self.service = service
+        usage = USAGES[service]
+
+        super().__init__(f"The service {service} used for {usage} is currently down.")
+
+
 class StationNotFoundError(Exception):
     """Raised when no train station could be found around a location."""
 

--- a/backend/transport_train.py
+++ b/backend/transport_train.py
@@ -27,6 +27,8 @@ from geo_validate_geometry import validate_geometry
 from models import (
     CountrySplitConfig,
     EmissionPart,
+    ExternalApiErrorCode,
+    ExternalServiceDownError,
     RouteNotFoundError,
     RouteResult,
     StationNotFoundError,
@@ -172,7 +174,7 @@ def retry_train_routing_with_nearby_points(
     departure_coords: tuple[float, float],
     arrival_location: str,
     arrival_coords: tuple[float, float],
-) -> RouteResult | None:
+) -> tuple[RouteResult | None, ExternalApiErrorCode | None]:
     """Retry train routing using nearby railway points.
 
     When direct train routing fails, this function searches for nearby railway
@@ -205,7 +207,7 @@ def retry_train_routing_with_nearby_points(
 def request_train_route(
     departure_coords: tuple[float, float],
     arrival_coords: tuple[float, float],
-) -> RouteResult | None:
+) -> tuple[RouteResult | None, ExternalApiErrorCode | None]:
     """Request a train route between two coordinates.
 
     The route geometry and path length are retrieved from the Signal
@@ -232,25 +234,35 @@ def request_train_route(
         "?overview=simplified&geometries=geojson"
     )
 
-    response = requests.get(url)
+    try:
+        response = requests.get(url, timeout=(3, 10))
+
+    # error handling
+    except requests.exceptions.Timeout:
+        logger.warning("Signal request timed out")
+        return None, "timeout"
+    except requests.exceptions.RequestException as exc:
+        logger.warning("Signal request failed: %s", exc)
+        return None, "error"
 
     if response.status_code != HTTPStatus.OK:
         logger.warning(
-            "Signal request failed with status code: %s",
+            "Signal request returned HTTP %s",
             response.status_code,
         )
-        return None
+        return None, "http_error"
 
+    # success
     routes = response.json().get("routes")
     if not routes or len(routes) == 0:
-        logger.info("Signal request successful, but no path found")
-        return None
+        logger.info("Signal found no routes")
+        return None, "no_route"
 
     route = routes[0]
     path_length_km = m_to_km(route["distance"])
     geometry = LineString(route["geometry"]["coordinates"])
 
-    return RouteResult(geometry=geometry, path_length_km=path_length_km)
+    return RouteResult(geometry=geometry, path_length_km=path_length_km), None
 
 
 def compute_train_trip(
@@ -287,18 +299,23 @@ def compute_train_trip(
     departure_coords = get_routing_coordinates(departure)
     arrival_coords = get_routing_coordinates(arrival)
 
-    result = request_train_route(departure_coords, arrival_coords)
+    result, error = request_train_route(departure_coords, arrival_coords)
 
     if result is None:
-        result = retry_train_routing_with_nearby_points(
+        if error != "no_route":
+            raise ExternalServiceDownError("signal")
+
+        result, error = retry_train_routing_with_nearby_points(
             departure.location,
             departure_coords,
             arrival.location,
             arrival_coords,
         )
 
-    if result is None:
-        raise RouteNotFoundError(departure.location, arrival.location, "train")
+        if result is None:
+            if error != "no_route":
+                raise ExternalServiceDownError("signal")
+            raise RouteNotFoundError(departure.location, arrival.location, "train")
 
     try:
         validate_geometry(departure_coords, arrival_coords, result.geometry)

--- a/backend/trip_service.py
+++ b/backend/trip_service.py
@@ -23,6 +23,7 @@ import sentry_sdk
 
 from models import (
     ApiPayload,
+    ExternalServiceDownError,
     RouteNotFoundError,
     StationNotFoundError,
     StepData,
@@ -74,6 +75,15 @@ def return_400_no_station(err: StationNotFoundError):
     return jsonify({"code": "NO_TRAIN_STATION", "city": err.city}), 400
 
 
+def return_503_external_service_down(err: ExternalServiceDownError):
+    with sentry_sdk.push_scope() as scope:
+        scope.set_tag("service", err.service)
+        scope.set_tag("error_type", "EXTERNAL_SERVICE_DOWN")
+        sentry_sdk.capture_exception(err)
+
+    return jsonify({"code": "EXTERNAL_SERVICE_DOWN", "service": err.service}), 503
+
+
 def compute_emissions(payload: ApiPayload):
     """Compute emissions and geometries for the requested trips.
 
@@ -104,6 +114,8 @@ def compute_emissions(payload: ApiPayload):
         return return_400_no_route(err)
     except StationNotFoundError as err:
         return return_400_no_station(err)
+    except ExternalServiceDownError as err:
+        return return_503_external_service_down(err)
     except Exception as err:
         raise TripComputationError from err
 

--- a/frontend/src/translations/english.json
+++ b/frontend/src/translations/english.json
@@ -72,6 +72,8 @@
       "ferryVehicle": "Seat + car",
       "ferryCabinVehicle": "Cabin + car",
       "errorModal": {
+        "EXTERNAL_SERVICE_DOWN_title": "Route calculation is temporarily unavailable",
+        "EXTERNAL_SERVICE_DOWN_content": "Our routing service is temporarily unavailable. Please try again later.",
         "NO_ROUTE_title": "No route found between {{departure}} and {{arrival}} by {{transport_mean}}",
         "NO_ROUTE_content": "We couldn't find a route. In particular, our routing algorithm cannot calculate routes that cross the sea. We recommend splitting your journey into several legs and trying again.",
         "NO_TRAIN_STATION_title": "No train station found near {{city}}",

--- a/frontend/src/translations/french.json
+++ b/frontend/src/translations/french.json
@@ -152,6 +152,8 @@
       "ferryVehicle": "Place assise + voiture",
       "ferryCabinVehicle": "Cabine + voiture",
       "errorModal": {
+        "EXTERNAL_SERVICE_DOWN_title": "Le calcul de l'itinéraire est temporairement indisponible",
+        "EXTERNAL_SERVICE_DOWN_content": "Notre service de calcul d'itinéraires ferroviaire est temporairement indisponible. Veuillez réessayer plus tard.",
         "NO_ROUTE_title": "Aucun itinéraire trouvé entre {{departure}} et {{arrival}} en {{transport_mean}}",
         "NO_ROUTE_content": "Nous n'avons pas trouvé d'itinéraire. Notre algorithme ne permet notamment pas de calculer des trajets traversant une mer. Nous vous conseillons de réessayer en découpant votre voyage en plusieurs étapes.",
         "NO_TRAIN_STATION_title": "Aucune gare trouvée autour de {{city}}",

--- a/frontend/src/translations/german.json
+++ b/frontend/src/translations/german.json
@@ -72,6 +72,8 @@
       "ferryVehicle": "Sitzplatz + auto",
       "ferryCabinVehicle": "Kabine + auto",
       "errorModal": {
+        "EXTERNAL_SERVICE_DOWN_title": "Die Routenberechnung ist vorübergehend nicht verfügbar",
+        "EXTERNAL_SERVICE_DOWN_content": "Unser Routenplanungsdienst ist vorübergehend nicht verfügbar. Bitte versuchen Sie es später erneut.",
         "NO_ROUTE_title": "Keine Route zwischen {{departure}} und {{arrival}} mit {{transport_mean}} gefunden",
         "NO_ROUTE_content": "Es konnte keine Route gefunden werden. Unser Routing-Algorithmus kann insbesondere keine Strecken berechnen, die ein Meer überqueren. Wir empfehlen, Ihre Reise in mehrere Etappen aufzuteilen und es erneut zu versuchen.",
         "NO_TRAIN_STATION_title": "Kein Bahnhof in der Nähe von {{city}} gefunden",

--- a/frontend/src/translations/italian.json
+++ b/frontend/src/translations/italian.json
@@ -72,6 +72,8 @@
       "ferryVehicle": "Sedute + macchina",
       "ferryCabinVehicle": "Cabina + macchina",
       "errorModal": {
+        "EXTERNAL_SERVICE_DOWN_title": "Il calcolo del percorso è temporaneamente non disponibile",
+        "EXTERNAL_SERVICE_DOWN_content": "Il nostro servizio di calcolo dei percorsi è temporaneamente non disponibile. Riprova più tardi.",
         "NO_ROUTE_title": "Nessun percorso trovato tra {{departure}} e {{arrival}} in {{transport_mean}}",
         "NO_ROUTE_content": "Non siamo riusciti a trovare un percorso. In particolare, il nostro algoritmo non è in grado di calcolare itinerari che attraversano il mare. Ti consigliamo di suddividere il viaggio in più tappe e riprovare.",
         "NO_TRAIN_STATION_title": "Nessuna stazione ferroviaria trovata nei pressi di {{city}}",

--- a/frontend/src/translations/spanish.json
+++ b/frontend/src/translations/spanish.json
@@ -72,6 +72,8 @@
       "ferryVehicle": "Asientos + auto",
       "ferryCabinVehicle": "Cabina + auto",
       "errorModal": {
+        "EXTERNAL_SERVICE_DOWN_title": "El cálculo de la ruta no está disponible temporalmente",
+        "EXTERNAL_SERVICE_DOWN_content": "Nuestro servicio de cálculo de rutas no está disponible temporalmente. Inténtalo de nuevo más tarde.",
         "NO_ROUTE_title": "No se encontró ninguna ruta entre {{departure}} y {{arrival}} en {{transport_mean}}",
         "NO_ROUTE_content": "No hemos podido encontrar una ruta. En particular, nuestro algoritmo no puede calcular trayectos que crucen el mar. Te recomendamos dividir el viaje en varias etapas y volver a intentarlo.",
         "NO_TRAIN_STATION_title": "No se encontró ninguna estación de tren cerca de {{city}}",


### PR DESCRIPTION
Signal is currently unavailable, causing requests to time out and workers to hit the 30-second timeout.

Handle external service failures explicitly, return 503 responses, and distinguish them from cases where no route is found.